### PR TITLE
Fix CPU usage calculation to use delta measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.0.8] - 2025-11-26
+
+### Fixed
+- **CPU Usage Calculation**: Fixed CPU usage metric to show real-time usage instead of cumulative average
+  - Changed from cumulative runtime to delta-based calculation between measurements
+  - Added 100ms minimum interval to prevent measurement jitter
+  - Now accurately reflects current CPU load, especially noticeable under stress testing
+  - First measurement returns 0%, subsequent calls show accurate real-time usage percentage
+
+---
+
 ## [0.0.7] - 2025-11-26
 
 ### Added

--- a/src/version.h
+++ b/src/version.h
@@ -6,7 +6,7 @@
 // Firmware version information
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 0
-#define VERSION_PATCH 7
+#define VERSION_PATCH 8
 
 // Build date (automatically set by compiler)
 #define BUILD_DATE __DATE__


### PR DESCRIPTION
## Summary

Fixes the CPU usage metric to show **real-time usage** instead of cumulative average since boot.

## Problem

The previous implementation calculated CPU usage based on cumulative runtime counters since boot, which meant:
- CPU usage percentage barely changed over time
- Under load, CPU would only increase by 1-2%
- Not responsive to current system activity

## Solution

Changed to **delta-based calculation**:
- Track previous runtime values
- Calculate usage based on the delta between measurements
- Added 100ms minimum interval to prevent measurement jitter
- Added bounds checking (0-100%)

## Results

- First measurement returns 0% (no previous data)
- Subsequent calls show accurate real-time CPU usage
- Much more responsive to actual load
- Noticeable improvement during stress testing

## Changes

- `src/app/web_portal.cpp`: Updated CPU calculation in `handleGetHealth()`
- `src/version.h`: Bumped to 0.0.8
- `CHANGELOG.md`: Added entry for version 0.0.8

## Testing

Tested with stress testing tool sending concurrent requests - CPU usage now accurately reflects load on ESP32-C3.