### PR TITLE
Home Assistant MQTT integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.0.16] - 2025-12-16
+
+### Added
+- MQTT + Home Assistant integration (PubSubClient)
+  - Home Assistant MQTT Discovery for device telemetry
+  - Availability topic (LWT) and retained state publishing
+  - Single JSON state topic with per-entity `value_template`
+- MQTT settings in the Network page (host/port/credentials/publish interval)
+- New developer guide: `docs/home-assistant-mqtt.md`
+
+### Changed
+- Refactored health/telemetry internals to `device_telemetry` (used by `/api/health` and MQTT publishing)
+- `/api/info` now reports `has_mqtt` so the portal can hide MQTT settings for MQTT-disabled builds
+- Documentation updated to reflect built-in MQTT/HA support and optional configuration
+
 ## [0.0.15] - 2025-12-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -337,7 +337,13 @@ Libraries are managed via `arduino-libraries.txt` for consistency across local a
 
 Libraries in `arduino-libraries.txt` are automatically installed by `setup.sh` and in GitHub Actions.
 
-**Note:** The template starts with no libraries configured. Uncomment or add libraries as needed for your project.
+**Note:** The template ships with a small set of libraries already configured; add or remove entries in `arduino-libraries.txt` as needed for your project.
+
+## 🏠 Home Assistant + MQTT
+
+When `HAS_MQTT` is enabled, the firmware can publish MQTT state and Home Assistant MQTT Discovery.
+
+- Developer guide: [docs/home-assistant-mqtt.md](docs/home-assistant-mqtt.md)
 
 See [docs/library-management.md](docs/library-management.md) for detailed guide.
 
@@ -489,6 +495,7 @@ usbipd list
 - [Build and Release Process](docs/build-and-release-process.md) - Project branding, build system, and release workflow
 - [WSL Development Guide](docs/wsl-development.md) - Windows/WSL setup
 - [Library Management](docs/library-management.md) - Managing dependencies
+- [Home Assistant + MQTT](docs/home-assistant-mqtt.md) - MQTT topics, HA discovery, and how to extend
 - [Changelog](CHANGELOG.md) - Version history and release notes
 
 ## 📄 License

--- a/arduino-libraries.txt
+++ b/arduino-libraries.txt
@@ -21,3 +21,6 @@ Async TCP@3.4.9
 # Note: NetBIOS library is included in ESP32 core (no separate install needed)
 
 # Add additional libraries below:
+
+# MQTT
+PubSubClient@2.8

--- a/docs/home-assistant-mqtt.md
+++ b/docs/home-assistant-mqtt.md
@@ -1,0 +1,217 @@
+# Home Assistant + MQTT Integration
+
+This project includes an optional MQTT integration designed for Home Assistant (HA) using **MQTT Discovery**.
+
+Key design choices:
+- **Single JSON state topic** (batched payload) for efficiency
+- **HA MQTT Discovery** for auto-creating entities
+- **Retained** discovery + state so HA can restart without losing entities/values
+- System/health entities are marked as **Diagnostic** in HA (`entity_category: diagnostic`)
+
+## Prerequisites
+
+- A reachable MQTT broker (Mosquitto, HA add-on, etc.)
+- Home Assistant with the MQTT integration enabled
+- Firmware built with `HAS_MQTT` enabled
+
+## Enable/Disable MQTT in Firmware
+
+MQTT support is controlled at compile time:
+- Default is defined in `src/app/board_config.h`
+- You can override per-board via `src/boards/<board>/board_overrides.h`
+
+When `HAS_MQTT` is disabled:
+- The UI hides MQTT settings (capability flag)
+- MQTT code is compiled out
+
+## Configure MQTT (Web Portal)
+
+Go to the **Network** page and fill in:
+- `MQTT Host` (required to enable MQTT)
+- `MQTT Port` (optional, default 1883)
+- `MQTT Username` / `MQTT Password` (optional)
+- `Publish Interval (seconds)`
+
+Behavior:
+- If `MQTT Host` is empty: device will not connect.
+- If `MQTT Host` is set:
+  - Device connects and publishes availability + discovery.
+  - Device publishes **one retained** state payload right after connect.
+  - If `Publish Interval > 0`: it also republishes state periodically.
+
+## Topics
+
+The device derives a **sanitized name** from the configured device name and uses it to build topics.
+
+- Base topic: `devices/<sanitized>`
+- Availability (LWT): `devices/<sanitized>/availability` (retained `online` / `offline`)
+- State (JSON): `devices/<sanitized>/health/state` (retained JSON)
+
+Home Assistant discovery topics:
+- `homeassistant/sensor/<sanitized>/<object_id>/config` (retained)
+
+## State Payload (JSON)
+
+The state topic publishes one JSON document that contains multiple fields (examples):
+- `uptime_seconds`
+- `reset_reason`
+- `cpu_usage`
+- `cpu_temperature`
+- `heap_free`, `heap_min`, `heap_fragmentation`
+- `flash_used`, `flash_total`
+- `wifi_rssi`
+
+Home Assistant entities use `value_template` to extract a single field, e.g.
+
+- `{{ value_json.cpu_usage }}`
+
+## Adding Custom Sensors (Step-by-Step)
+
+This project is intentionally lightweight: add a JSON key + add a discovery entry.
+
+### 1) Add your JSON fields to the MQTT payload
+
+Edit `src/app/device_telemetry.cpp` in `device_telemetry_fill_mqtt()`.
+
+Example (ambient sensor):
+
+```cpp
+// Example: external temperature/humidity
+// doc["temperature"] = 23.4;
+// doc["humidity"] = 55.2;
+```
+
+Notes:
+- `cpu_temperature` is reserved for SoC/internal temperature.
+- `temperature` is intended for external/ambient temperature.
+
+### 2) Register Home Assistant entities via discovery
+
+Edit `src/app/ha_discovery.cpp` in `ha_discovery_publish_health()` (kept at the top of the file).
+
+Example (normal Sensors category):
+
+```cpp
+// publish_sensor_config(mqtt, "temperature", "Temperature", "{{ value_json.temperature }}", "°C", "temperature", "measurement", nullptr);
+// publish_sensor_config(mqtt, "humidity", "Humidity", "{{ value_json.humidity }}", "%", "humidity", "measurement", nullptr);
+```
+
+Tip:
+- Pass `"diagnostic"` as the last argument to put an entity in HA’s Diagnostic category.
+- Pass `nullptr` (or omit the argument if you add your own wrapper) to keep it as a normal Sensor.
+
+### 3) Build and flash
+
+```bash
+./build.sh esp32c3
+./upload.sh esp32c3
+./monitor.sh
+```
+
+### 4) If entities don’t update in Home Assistant
+
+Discovery and state are **retained**, so HA may keep old configs if you change them.
+
+Typical reset options:
+- Remove the device/entities in HA and reboot the device.
+- Or delete retained discovery topics under `homeassistant/sensor/<sanitized>/.../config` and reboot.
+
+## Event-Driven Sensors (Presence)
+
+Sometimes you want **most telemetry** to keep publishing on an interval, but a specific sensor (like **presence**) to update **immediately when it changes**.
+
+There are two viable approaches.
+
+### Option A (Quick + Simple): Force-publish the existing JSON state immediately
+
+This keeps the “single JSON state topic” design intact:
+- Leave your existing interval publishing enabled (`Publish Interval (seconds) > 0`).
+- When presence changes, publish an immediate update by republishing the same retained JSON state topic.
+
+Tradeoff:
+- Presence will still be present in the JSON payload, so it will also get re-sent during interval publishes (even if unchanged).
+
+**Recommended when:** you don’t care about presence being included in periodic publishes.
+
+**Example (called from your sensor code on edge):**
+
+```cpp
+#include <ArduinoJson.h>
+#include "device_telemetry.h"
+
+// mqtt is your MqttManager instance
+void publish_presence_edge_force_health_state(MqttManager &mqtt) {
+    if (!mqtt.connected()) return;
+
+    JsonDocument doc;
+    device_telemetry_fill_mqtt(doc);
+    mqtt.publishJson(mqtt.healthStateTopic(), doc, true);
+}
+```
+
+Where to store the presence value:
+- Keep the latest presence state in a global/module-level variable (or getter) that `device_telemetry_fill_mqtt()` reads when it builds the payload.
+
+### Option B (Recommended): Separate presence topic (event-driven) + keep interval telemetry
+
+This keeps interval telemetry clean and makes presence fully event-driven:
+- Keep the existing interval JSON telemetry on: `devices/<sanitized>/health/state`
+- Add a dedicated presence topic:
+  - `devices/<sanitized>/presence/state` with payload `ON` / `OFF` (retained)
+- Register presence in HA as a **binary_sensor** that points at that topic
+
+Benefits:
+- Presence updates only when it changes (no periodic republish).
+- HA gets the right entity type (binary sensor) and semantics.
+
+**Suggested additions (minimal API surface):**
+
+1) Add a helper publish function (example) somewhere in your app code:
+
+```cpp
+// mqtt is your MqttManager instance
+// presence is your boolean state
+void publish_presence_state(MqttManager &mqtt, bool presence) {
+    if (!mqtt.connected()) return;
+
+    char topic[160];
+    snprintf(topic, sizeof(topic), "%s/presence/state", mqtt.baseTopic());
+
+    mqtt.publishImmediate(topic, presence ? "ON" : "OFF", true);
+}
+```
+
+2) Add HA discovery for the presence binary_sensor.
+
+Today, [src/app/ha_discovery.cpp](src/app/ha_discovery.cpp) only publishes `sensor` discovery entries.
+For presence, the recommended pattern is adding a small `publish_binary_sensor_config(...)` helper that publishes:
+- topic: `homeassistant/binary_sensor/<sanitized>/<object_id>/config`
+- `stat_t`: `~/presence/state`
+- `pl_on`: `ON`
+- `pl_off`: `OFF`
+
+Example config payload shape (pseudo-code):
+
+```cpp
+// publish_binary_sensor_config(mqtt,
+//     "presence",
+//     "Presence",
+//     "presence",   // device_class
+//     nullptr        // entity_category
+// );
+```
+
+Operational notes:
+- Use retained publishes for presence so HA can recover the last known state after restart.
+- Add basic debouncing in your sensor logic so you don’t spam MQTT during noisy transitions.
+
+## Troubleshooting
+
+- Nothing appears in HA:
+  - Verify MQTT broker address/credentials.
+  - Check serial logs for `[MQTT] Connected` and `Publishing HA discovery`.
+- Entities exist but values are `unknown`:
+  - Ensure the state topic is being published (`devices/<sanitized>/health/state`).
+  - Verify the JSON key matches the `value_template`.
+- You changed names and got duplicate entities:
+  - Clear retained discovery topics and reboot.

--- a/docs/library-management.md
+++ b/docs/library-management.md
@@ -2,7 +2,7 @@
 
 This project uses a configuration file to manage Arduino libraries, ensuring consistent dependencies across local development and CI/CD environments.
 
-> **Note:** The template starts with no libraries configured. Example libraries (`WiFi` and `ArduinoJson`) are provided as comments in `arduino-libraries.txt`. Uncomment or add libraries as needed for your project.
+> **Note:** The template ships with a small set of libraries already configured. Treat `arduino-libraries.txt` as the source of truth and add/remove entries as your project evolves.
 
 ## Configuration File
 
@@ -147,22 +147,19 @@ Or visit: https://www.arduinolibraries.info/
 # Initial setup
 ./setup.sh
 
-# Later, you need an MQTT library
-./library.sh search mqtt
-# Shows: PubSubClient by Nick O'Leary
-
-# Add it to your project
-./library.sh add PubSubClient
+# Add a new dependency (example: BME280 sensor)
+./library.sh search bme280
+./library.sh add "Adafruit BME280 Library"
 
 # Verify it's configured
 ./library.sh list
 
 # Commit the change
 git add arduino-libraries.txt
-git commit -m "Add MQTT support via PubSubClient"
+git commit -m "Add BME280 sensor library"
 git push
 
-# GitHub Actions will automatically install PubSubClient during CI
+# GitHub Actions will automatically install configured libraries during CI
 ```
 
 ## Troubleshooting

--- a/docs/library-quick-reference.md
+++ b/docs/library-quick-reference.md
@@ -32,12 +32,12 @@
 
 1. **Find a library:**
    ```bash
-   ./library.sh search mqtt
+   ./library.sh search bme280
    ```
 
 2. **Add to project:**
    ```bash
-   ./library.sh add PubSubClient
+   ./library.sh add "Adafruit BME280 Library"
    ```
 
 3. **Verify:**
@@ -48,7 +48,7 @@
 4. **Commit:**
    ```bash
    git add arduino-libraries.txt
-   git commit -m "Add MQTT library"
+   git commit -m "Add BME280 sensor library"
    ```
 
 5. **CI/CD automatically installs it** via `setup.sh`
@@ -77,7 +77,7 @@
 - **Local Setup**: `./setup.sh` reads `arduino-libraries.txt` and installs all libraries
 - **CI/CD**: GitHub Actions runs `./setup.sh`, automatically installing libraries
 - **Version Control**: `arduino-libraries.txt` tracks dependencies across team/environments
-- **Initial State**: Template starts with no libraries configured (examples are commented out)
+- **Initial State**: Template ships with a small set of libraries already configured; customize `arduino-libraries.txt` as needed
 
 ## Format of arduino-libraries.txt
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -228,8 +228,8 @@ build/
 ./setup.sh
 
 # Add libraries as needed
-./library.sh search mqtt
-./library.sh add PubSubClient
+./library.sh search bme280
+./library.sh add "Adafruit BME280 Library"
 
 # Development cycle
 ./build.sh              # Compile firmware

--- a/docs/web-portal.md
+++ b/docs/web-portal.md
@@ -215,6 +215,9 @@ Real-time device health monitoring integrated as a header badge with expandable 
   - Gateway (required if fixed IP set)
   - DNS Server 1 (optional, defaults to gateway)
   - DNS Server 2 (optional)
+- **📡 MQTT Settings (Optional)**: MQTT broker settings
+  - Only shown when MQTT support is enabled in firmware (`HAS_MQTT`)
+  - Host, port, username/password, publish interval
 
 **Layout:** 
 - WiFi + Device Settings side-by-side on desktop

--- a/src/app/board_config.h
+++ b/src/app/board_config.h
@@ -37,6 +37,11 @@
 #define HAS_BUILTIN_LED false
 #endif
 
+// MQTT / Home Assistant integration
+#ifndef HAS_MQTT
+#define HAS_MQTT true
+#endif
+
 #ifndef LED_PIN
 #define LED_PIN 2  // Common GPIO for ESP32 boards
 #endif

--- a/src/app/config_manager.h
+++ b/src/app/config_manager.h
@@ -27,6 +27,11 @@
 #define CONFIG_IP_STR_MAX_LEN 16
 #define CONFIG_DUMMY_MAX_LEN 64
 
+// MQTT settings
+#define CONFIG_MQTT_HOST_MAX_LEN 64
+#define CONFIG_MQTT_USERNAME_MAX_LEN 32
+#define CONFIG_MQTT_PASSWORD_MAX_LEN 64
+
 // Configuration structure
 struct DeviceConfig {
     // WiFi credentials
@@ -45,6 +50,13 @@ struct DeviceConfig {
     
     // Dummy setting (example for extensibility)
     char dummy_setting[CONFIG_DUMMY_MAX_LEN];
+
+    // MQTT / Home Assistant integration settings (all optional)
+    char mqtt_host[CONFIG_MQTT_HOST_MAX_LEN];
+    uint16_t mqtt_port; // default to 1883 when mqtt_host set and mqtt_port is 0
+    char mqtt_username[CONFIG_MQTT_USERNAME_MAX_LEN];
+    char mqtt_password[CONFIG_MQTT_PASSWORD_MAX_LEN];
+    uint16_t mqtt_interval_seconds; // 0 disables periodic publish
     
     // Validation flag (magic number to detect valid config)
     uint32_t magic;

--- a/src/app/device_telemetry.cpp
+++ b/src/app/device_telemetry.cpp
@@ -1,0 +1,213 @@
+#include "device_telemetry.h"
+
+#include <Arduino.h>
+#include <WiFi.h>
+#include "soc/soc_caps.h"
+
+// Temperature sensor support (ESP32-C3, ESP32-S2, ESP32-S3, ESP32-C2, ESP32-C6, ESP32-H2)
+#if SOC_TEMP_SENSOR_SUPPORTED
+#include "driver/temperature_sensor.h"
+#endif
+
+// CPU usage tracking (delta-based)
+static uint32_t last_idle_runtime = 0;
+static uint32_t last_total_runtime = 0;
+static unsigned long last_cpu_check = 0;
+
+// Flash/sketch metadata caching (avoid re-entrant ESP-IDF image/mmap helpers)
+static bool flash_cache_initialized = false;
+static size_t cached_sketch_size = 0;
+static size_t cached_free_sketch_space = 0;
+
+static void fill_common(JsonDocument &doc, bool include_ip_and_channel, bool include_debug_fields);
+
+void device_telemetry_fill_api(JsonDocument &doc) {
+    fill_common(doc, true, true);
+
+    // =====================================================================
+    // USER-EXTEND: Add your own sensors to the web "health" API (/api/health)
+    // =====================================================================
+    // If you want your external sensors to show up in the web portal health widget,
+    // add fields here.
+    //
+    // IMPORTANT:
+    // - The key "cpu_temperature" is used for the SoC/internal temperature.
+    //   You can safely use "temperature" for an external/ambient sensor.
+    // - If you also publish these over MQTT, keep the JSON keys identical in
+    //   device_telemetry_fill_mqtt() so you can reuse the same HA templates.
+    //
+    // Example (commented out):
+    // doc["temperature"] = 23.4;
+    // doc["humidity"] = 55.2;
+}
+
+void device_telemetry_fill_mqtt(JsonDocument &doc) {
+    fill_common(doc, false, false);
+
+    // =====================================================================
+    // USER-EXTEND: Add your own sensors to the MQTT state payload
+    // =====================================================================
+    // The MQTT integration publishes ONE batched JSON document (retained) to:
+    //   devices/<sanitized>/health/state
+    // Home Assistant entities then extract values via value_template, e.g.:
+    //   {{ value_json.temperature }}
+    //
+    // Add your custom sensor fields below.
+    //
+    // IMPORTANT:
+    // - The key "cpu_temperature" is used for the SoC/internal temperature.
+    //   You can safely use "temperature" for an external/ambient sensor.
+    //
+    // Example (commented out):
+    // doc["temperature"] = 23.4;
+    // doc["humidity"] = 55.2;
+}
+
+void device_telemetry_init() {
+    if (flash_cache_initialized) return;
+
+    cached_sketch_size = ESP.getSketchSize();
+    cached_free_sketch_space = ESP.getFreeSketchSpace();
+    flash_cache_initialized = true;
+}
+
+size_t device_telemetry_sketch_size() {
+    if (!flash_cache_initialized) {
+        device_telemetry_init();
+    }
+    return cached_sketch_size;
+}
+
+size_t device_telemetry_free_sketch_space() {
+    if (!flash_cache_initialized) {
+        device_telemetry_init();
+    }
+    return cached_free_sketch_space;
+}
+
+static void fill_common(JsonDocument &doc, bool include_ip_and_channel, bool include_debug_fields) {
+    // System
+    uint64_t uptime_us = esp_timer_get_time();
+    doc["uptime_seconds"] = uptime_us / 1000000;
+
+    // Reset reason
+    esp_reset_reason_t reset_reason = esp_reset_reason();
+    const char* reset_str = "Unknown";
+    switch (reset_reason) {
+        case ESP_RST_POWERON:   reset_str = "Power On"; break;
+        case ESP_RST_SW:        reset_str = "Software"; break;
+        case ESP_RST_PANIC:     reset_str = "Panic"; break;
+        case ESP_RST_INT_WDT:   reset_str = "Interrupt WDT"; break;
+        case ESP_RST_TASK_WDT:  reset_str = "Task WDT"; break;
+        case ESP_RST_WDT:       reset_str = "WDT"; break;
+        case ESP_RST_DEEPSLEEP: reset_str = "Deep Sleep"; break;
+        case ESP_RST_BROWNOUT:  reset_str = "Brownout"; break;
+        case ESP_RST_SDIO:      reset_str = "SDIO"; break;
+        default: break;
+    }
+    doc["reset_reason"] = reset_str;
+
+    // CPU (API includes cpu_freq; MQTT keeps payload smaller)
+    if (include_debug_fields) {
+        doc["cpu_freq"] = ESP.getCpuFreqMHz();
+    }
+
+    // CPU usage via IDLE task delta calculation
+    TaskStatus_t task_stats[16];
+    uint32_t total_runtime;
+    int task_count = uxTaskGetSystemState(task_stats, 16, &total_runtime);
+
+    uint32_t idle_runtime = 0;
+    for (int i = 0; i < task_count; i++) {
+        if (strstr(task_stats[i].pcTaskName, "IDLE") != nullptr) {
+            idle_runtime += task_stats[i].ulRunTimeCounter;
+        }
+    }
+
+    unsigned long now = millis();
+    int cpu_usage = 0;
+
+    if (last_cpu_check > 0 && (now - last_cpu_check) > 100) {
+        uint32_t idle_delta = idle_runtime - last_idle_runtime;
+        uint32_t total_delta = total_runtime - last_total_runtime;
+
+        if (total_delta > 0) {
+            float idle_percent = ((float)idle_delta / total_delta) * 100.0;
+            cpu_usage = (int)(100.0 - idle_percent);
+            if (cpu_usage < 0) cpu_usage = 0;
+            if (cpu_usage > 100) cpu_usage = 100;
+        }
+    }
+
+    last_idle_runtime = idle_runtime;
+    last_total_runtime = total_runtime;
+    last_cpu_check = now;
+
+    doc["cpu_usage"] = cpu_usage;
+
+    // CPU / SoC temperature
+#if SOC_TEMP_SENSOR_SUPPORTED
+    float temp_celsius = 0;
+    temperature_sensor_handle_t temp_sensor = NULL;
+    temperature_sensor_config_t temp_sensor_config = TEMPERATURE_SENSOR_CONFIG_DEFAULT(-10, 80);
+
+    if (temperature_sensor_install(&temp_sensor_config, &temp_sensor) == ESP_OK) {
+        if (temperature_sensor_enable(temp_sensor) == ESP_OK) {
+            if (temperature_sensor_get_celsius(temp_sensor, &temp_celsius) == ESP_OK) {
+                doc["cpu_temperature"] = (int)temp_celsius;
+            } else {
+                doc["cpu_temperature"] = nullptr;
+            }
+            temperature_sensor_disable(temp_sensor);
+        } else {
+            doc["cpu_temperature"] = nullptr;
+        }
+        temperature_sensor_uninstall(temp_sensor);
+    } else {
+        doc["cpu_temperature"] = nullptr;
+    }
+#else
+    doc["cpu_temperature"] = nullptr;
+#endif
+
+    // Memory
+    doc["heap_free"] = ESP.getFreeHeap();
+    doc["heap_min"] = ESP.getMinFreeHeap();
+    if (include_debug_fields) {
+        doc["heap_size"] = ESP.getHeapSize();
+    }
+
+    // Heap fragmentation
+    size_t largest_block = ESP.getMaxAllocHeap();
+    size_t free_heap = ESP.getFreeHeap();
+    float fragmentation = 0;
+    if (free_heap > 0) {
+        fragmentation = (1.0 - ((float)largest_block / free_heap)) * 100.0;
+    }
+    doc["heap_fragmentation"] = (int)fragmentation;
+
+    // Flash usage
+    const size_t sketch_size = device_telemetry_sketch_size();
+    const size_t free_sketch_space = device_telemetry_free_sketch_space();
+    doc["flash_used"] = sketch_size;
+    doc["flash_total"] = sketch_size + free_sketch_space;
+
+    // WiFi stats (only if connected)
+    if (WiFi.status() == WL_CONNECTED) {
+        doc["wifi_rssi"] = WiFi.RSSI();
+
+        if (include_ip_and_channel) {
+            doc["wifi_channel"] = WiFi.channel();
+            doc["ip_address"] = WiFi.localIP().toString();
+            doc["hostname"] = WiFi.getHostname();
+        }
+    } else {
+        doc["wifi_rssi"] = nullptr;
+
+        if (include_ip_and_channel) {
+            doc["wifi_channel"] = nullptr;
+            doc["ip_address"] = nullptr;
+            doc["hostname"] = nullptr;
+        }
+    }
+}

--- a/src/app/device_telemetry.h
+++ b/src/app/device_telemetry.h
@@ -1,0 +1,21 @@
+#ifndef DEVICE_TELEMETRY_H
+#define DEVICE_TELEMETRY_H
+
+#include <ArduinoJson.h>
+
+// Initializes cached values used by device telemetry (safe to call multiple times).
+// This exists to avoid re-entrant calls into ESP-IDF image helpers from different tasks.
+void device_telemetry_init();
+
+// Cached flash/sketch metadata helpers.
+size_t device_telemetry_sketch_size();
+size_t device_telemetry_free_sketch_space();
+
+// Fill a JsonDocument with device telemetry for the web API (/api/health).
+void device_telemetry_fill_api(JsonDocument &doc);
+
+// Fill a JsonDocument with device telemetry optimized for MQTT publishing.
+// Intentionally excludes volatile/low-value fields like IP address.
+void device_telemetry_fill_mqtt(JsonDocument &doc);
+
+#endif // DEVICE_TELEMETRY_H

--- a/src/app/ha_discovery.cpp
+++ b/src/app/ha_discovery.cpp
@@ -1,0 +1,123 @@
+#include "ha_discovery.h"
+
+#include "board_config.h"
+
+#if HAS_MQTT
+
+#include "mqtt_manager.h"
+#include "web_assets.h" // PROJECT_DISPLAY_NAME
+#include "../version.h" // FIRMWARE_VERSION
+#include <ArduinoJson.h>
+
+static bool publish_sensor_config(
+    MqttManager &mqtt,
+    const char *object_id,
+    const char *name_suffix,
+    const char *value_template,
+    const char *unit_of_measurement,
+    const char *device_class,
+    const char *state_class,
+    const char *entity_category
+);
+
+void ha_discovery_publish_health(MqttManager &mqtt) {
+    // Notes:
+    // - Single JSON publish model: all entities share the same stat_t.
+    // - value_template extracts fields from the JSON payload.
+
+    publish_sensor_config(mqtt, "uptime", "Uptime", "{{ value_json.uptime_seconds }}", "s", "duration", "measurement", "diagnostic");
+    publish_sensor_config(mqtt, "reset_reason", "Reset Reason", "{{ value_json.reset_reason }}", "", "", "", "diagnostic");
+
+    publish_sensor_config(mqtt, "cpu_usage", "CPU Usage", "{{ value_json.cpu_usage }}", "%", "", "measurement", "diagnostic");
+    publish_sensor_config(mqtt, "cpu_temperature", "Core Temp", "{{ value_json.cpu_temperature }}", "°C", "temperature", "measurement", "diagnostic");
+
+    publish_sensor_config(mqtt, "heap_free", "Free Heap", "{{ value_json.heap_free }}", "B", "", "measurement", "diagnostic");
+    publish_sensor_config(mqtt, "heap_min", "Min Free Heap", "{{ value_json.heap_min }}", "B", "", "measurement", "diagnostic");
+    publish_sensor_config(mqtt, "heap_fragmentation", "Heap Fragmentation", "{{ value_json.heap_fragmentation }}", "%", "", "measurement", "diagnostic");
+
+    publish_sensor_config(mqtt, "flash_used", "Flash Used", "{{ value_json.flash_used }}", "B", "", "measurement", "diagnostic");
+    publish_sensor_config(mqtt, "flash_total", "Flash Total", "{{ value_json.flash_total }}", "B", "", "measurement", "diagnostic");
+
+    publish_sensor_config(mqtt, "wifi_rssi", "WiFi RSSI", "{{ value_json.wifi_rssi }}", "dBm", "signal_strength", "measurement", "diagnostic");
+
+    // =====================================================================
+    // USER-EXTEND: Add your own Home Assistant entities here
+    // =====================================================================
+    // To add new sensors (e.g. ambient temperature + humidity), you typically:
+    //   1) Add JSON fields to device_telemetry_fill_mqtt() in device_telemetry.cpp
+    //   2) Add matching discovery entries below (value_template must match keys)
+    //
+    // Example (commented out): External temperature/humidity
+    // (These will show up under the normal Sensors category in Home Assistant.)
+    // publish_sensor_config(mqtt, "temperature", "Temperature", "{{ value_json.temperature }}", "°C", "temperature", "measurement", nullptr);
+    // publish_sensor_config(mqtt, "humidity", "Humidity", "{{ value_json.humidity }}", "%", "humidity", "measurement", nullptr);
+}
+
+static bool publish_sensor_config(
+    MqttManager &mqtt,
+    const char *object_id,
+    const char *name_suffix,
+    const char *value_template,
+    const char *unit_of_measurement,
+    const char *device_class,
+    const char *state_class,
+    const char *entity_category = nullptr
+) {
+    char topic[160];
+    snprintf(topic, sizeof(topic), "homeassistant/sensor/%s/%s/config", mqtt.sanitizedName(), object_id);
+
+    JsonDocument doc;
+
+    // Use base topic shortcut to keep discovery payload small
+    doc["~"] = mqtt.baseTopic();
+
+    // Friendly name in payload
+    // Keep entity name short; HA already groups entities under the device name.
+    // This also avoids HA generating entity_id values that repeat the device name.
+    doc["name"] = name_suffix;
+
+    // Provide a stable object_id that includes the device name once.
+    // HA uses this to generate entity_id like: sensor.<sanitized>_<object_id>.
+    char ha_object_id[96];
+    snprintf(ha_object_id, sizeof(ha_object_id), "%s_%s", mqtt.sanitizedName(), object_id);
+    doc["object_id"] = ha_object_id;
+
+    if (entity_category && strlen(entity_category) > 0) {
+        doc["entity_category"] = entity_category;
+    }
+
+    // Stable unique id (sanitized name + object id)
+    char uniq_id[96];
+    snprintf(uniq_id, sizeof(uniq_id), "%s_%s", mqtt.sanitizedName(), object_id);
+    doc["uniq_id"] = uniq_id;
+
+    doc["stat_t"] = "~/health/state";
+    doc["val_tpl"] = value_template;
+
+    // Availability
+    doc["avty_t"] = "~/availability";
+    doc["pl_avail"] = "online";
+    doc["pl_not_avail"] = "offline";
+
+    if (unit_of_measurement && strlen(unit_of_measurement) > 0) {
+        doc["unit_of_meas"] = unit_of_measurement;
+    }
+    if (device_class && strlen(device_class) > 0) {
+        doc["dev_cla"] = device_class;
+    }
+    if (state_class && strlen(state_class) > 0) {
+        doc["stat_cla"] = state_class;
+    }
+
+    // Device block (kept minimal)
+    JsonObject dev = doc["dev"].to<JsonObject>();
+    JsonArray ids = dev["ids"].to<JsonArray>();
+    ids.add(mqtt.sanitizedName());
+    dev["name"] = mqtt.friendlyName();
+    dev["mdl"] = PROJECT_DISPLAY_NAME;
+    dev["sw"] = FIRMWARE_VERSION;
+
+    return mqtt.publishJson(topic, doc, true);
+}
+
+#endif // HAS_MQTT

--- a/src/app/ha_discovery.h
+++ b/src/app/ha_discovery.h
@@ -1,0 +1,17 @@
+#ifndef HA_DISCOVERY_H
+#define HA_DISCOVERY_H
+
+#include <Arduino.h>
+#include "board_config.h"
+
+#if HAS_MQTT
+
+class MqttManager;
+
+// Publish Home Assistant MQTT discovery configuration for the health sensors.
+// Intended to be called once per boot after MQTT connects.
+void ha_discovery_publish_health(MqttManager &mqtt);
+
+#endif // HAS_MQTT
+
+#endif // HA_DISCOVERY_H

--- a/src/app/mqtt_manager.cpp
+++ b/src/app/mqtt_manager.cpp
@@ -1,0 +1,202 @@
+#include "mqtt_manager.h"
+
+#include "board_config.h"
+
+#if HAS_MQTT
+
+#include "ha_discovery.h"
+#include "device_telemetry.h"
+#include "log_manager.h"
+
+MqttManager::MqttManager() : _client(_net) {}
+
+void MqttManager::begin(const DeviceConfig *config, const char *friendly_name, const char *sanitized_name) {
+    _config = config;
+
+    if (friendly_name) {
+        strlcpy(_friendly_name, friendly_name, sizeof(_friendly_name));
+    }
+    if (sanitized_name) {
+        strlcpy(_sanitized_name, sanitized_name, sizeof(_sanitized_name));
+    }
+
+    // Safety: if sanitization produced an empty string, fall back to a stable default.
+    if (strlen(_sanitized_name) == 0) {
+        strlcpy(_sanitized_name, "esp32", sizeof(_sanitized_name));
+    }
+
+    snprintf(_base_topic, sizeof(_base_topic), "devices/%s", _sanitized_name);
+    snprintf(_availability_topic, sizeof(_availability_topic), "%s/availability", _base_topic);
+    snprintf(_health_state_topic, sizeof(_health_state_topic), "%s/health/state", _base_topic);
+
+    _client.setBufferSize(MQTT_MAX_PACKET_SIZE);
+
+    _discovery_published_this_boot = false;
+    _last_reconnect_attempt_ms = 0;
+    _last_health_publish_ms = 0;
+}
+
+bool MqttManager::connectEnabled() const {
+    if (!_config) return false;
+    if (strlen(_config->mqtt_host) == 0) return false;
+    return true;
+}
+
+uint16_t MqttManager::resolvedPort() const {
+    if (!_config) return 1883;
+    return _config->mqtt_port > 0 ? _config->mqtt_port : 1883;
+}
+
+bool MqttManager::enabled() const {
+    // Enabled = we should connect to the broker.
+    return connectEnabled();
+}
+
+bool MqttManager::publishEnabled() const {
+    // Publishing health periodically is optional.
+    if (!_config) return false;
+    if (!connectEnabled()) return false;
+    return _config->mqtt_interval_seconds > 0;
+}
+
+bool MqttManager::connected() {
+    return _client.connected();
+}
+
+bool MqttManager::publish(const char *topic, const char *payload, bool retained) {
+    if (!enabled() || !_client.connected()) return false;
+    if (!topic || !payload) return false;
+
+    return _client.publish(topic, payload, retained);
+}
+
+bool MqttManager::publishJson(const char *topic, JsonDocument &doc, bool retained) {
+    if (!topic) return false;
+
+    String payload;
+    serializeJson(doc, payload);
+    return publish(topic, payload.c_str(), retained);
+}
+
+bool MqttManager::publishImmediate(const char *topic, const char *payload, bool retained) {
+    return publish(topic, payload, retained);
+}
+
+void MqttManager::publishAvailability(bool online) {
+    if (!_client.connected()) return;
+    _client.publish(_availability_topic, online ? "online" : "offline", true);
+}
+
+void MqttManager::publishDiscoveryOncePerBoot() {
+    if (_discovery_published_this_boot) return;
+
+    Logger.logMessage("MQTT", "Publishing HA discovery");
+    ha_discovery_publish_health(*this);
+    _discovery_published_this_boot = true;
+}
+
+void MqttManager::publishHealthNow() {
+    if (!_client.connected()) return;
+
+    JsonDocument doc;
+    device_telemetry_fill_mqtt(doc);
+
+    String payload;
+    serializeJson(doc, payload);
+    _client.publish(_health_state_topic, payload.c_str(), true);
+}
+
+void MqttManager::publishHealthIfDue() {
+    if (!_client.connected()) return;
+    if (!publishEnabled()) return;
+
+    unsigned long now = millis();
+    unsigned long interval_ms = (unsigned long)_config->mqtt_interval_seconds * 1000UL;
+
+    if (_last_health_publish_ms == 0 || (now - _last_health_publish_ms) >= interval_ms) {
+        JsonDocument doc;
+        device_telemetry_fill_mqtt(doc);
+
+        String payload;
+        serializeJson(doc, payload);
+        bool ok = _client.publish(_health_state_topic, payload.c_str(), true);
+
+        if (ok) {
+            _last_health_publish_ms = now;
+        }
+    }
+}
+
+void MqttManager::ensureConnected() {
+    if (!enabled()) return;
+    if (WiFi.status() != WL_CONNECTED) return;
+
+    if (_client.connected()) return;
+
+    unsigned long now = millis();
+    if (_last_reconnect_attempt_ms > 0 && (now - _last_reconnect_attempt_ms) < 5000) {
+        return;
+    }
+    _last_reconnect_attempt_ms = now;
+
+    _client.setServer(_config->mqtt_host, resolvedPort());
+
+    // Client ID: sanitized name
+    char client_id[96];
+    snprintf(client_id, sizeof(client_id), "%s", _sanitized_name);
+
+    bool has_user = strlen(_config->mqtt_username) > 0;
+    bool has_pass = strlen(_config->mqtt_password) > 0;
+
+    Logger.logMessagef("MQTT", "Connecting to %s:%d", _config->mqtt_host, resolvedPort());
+
+    bool connected = false;
+    if (has_user) {
+        const char *pass = has_pass ? _config->mqtt_password : "";
+        connected = _client.connect(
+            client_id,
+            _config->mqtt_username,
+            pass,
+            _availability_topic,
+            0,
+            true,
+            "offline"
+        );
+    } else {
+        connected = _client.connect(
+            client_id,
+            _availability_topic,
+            0,
+            true,
+            "offline"
+        );
+    }
+
+    if (connected) {
+        Logger.logMessage("MQTT", "Connected");
+        publishAvailability(true);
+        publishDiscoveryOncePerBoot();
+
+        // Publish a single retained state after connect so HA entities have values,
+        // even when periodic publishing is disabled (interval = 0).
+        publishHealthNow();
+
+        // If periodic publishing is enabled, start interval timing from now.
+        _last_health_publish_ms = millis();
+    } else {
+        Logger.logMessagef("MQTT", "Connect failed (state %d)", _client.state());
+    }
+}
+
+void MqttManager::loop() {
+    if (!enabled()) return;
+
+    ensureConnected();
+
+    if (_client.connected()) {
+        _client.loop();
+        publishHealthIfDue();
+    }
+}
+
+#endif // HAS_MQTT

--- a/src/app/mqtt_manager.h
+++ b/src/app/mqtt_manager.h
@@ -1,0 +1,75 @@
+#ifndef MQTT_MANAGER_H
+#define MQTT_MANAGER_H
+
+#include <Arduino.h>
+#include "board_config.h"
+
+#if HAS_MQTT
+
+// PubSubClient uses MQTT_MAX_PACKET_SIZE at compile time
+#ifndef MQTT_MAX_PACKET_SIZE
+#define MQTT_MAX_PACKET_SIZE 1024
+#endif
+
+#include <WiFi.h>
+#include <PubSubClient.h>
+#include <ArduinoJson.h>
+
+#include "config_manager.h"
+
+class MqttManager {
+public:
+    MqttManager();
+
+    void begin(const DeviceConfig *config, const char *friendly_name, const char *sanitized_name);
+    void loop();
+
+    bool enabled() const;
+    bool publishEnabled() const;
+    bool connected();
+
+    // Publish helpers
+    bool publish(const char *topic, const char *payload, bool retained);
+    bool publishJson(const char *topic, JsonDocument &doc, bool retained);
+
+    // Immediate publish API (topic is full topic string)
+    bool publishImmediate(const char *topic, const char *payload, bool retained);
+
+    // Topic helpers
+    const char *baseTopic() const { return _base_topic; }
+    const char *availabilityTopic() const { return _availability_topic; }
+    const char *healthStateTopic() const { return _health_state_topic; }
+
+    const char *friendlyName() const { return _friendly_name; }
+    const char *sanitizedName() const { return _sanitized_name; }
+
+private:
+    void ensureConnected();
+    void publishAvailability(bool online);
+    void publishDiscoveryOncePerBoot();
+    void publishHealthNow();
+    void publishHealthIfDue();
+
+    bool connectEnabled() const;
+    uint16_t resolvedPort() const;
+
+    WiFiClient _net;
+    PubSubClient _client;
+
+    const DeviceConfig *_config = nullptr;
+    char _friendly_name[CONFIG_DEVICE_NAME_MAX_LEN] = {0};
+    char _sanitized_name[CONFIG_DEVICE_NAME_MAX_LEN] = {0};
+
+    char _base_topic[96] = {0};
+    char _availability_topic[128] = {0};
+    char _health_state_topic[128] = {0};
+
+    bool _discovery_published_this_boot = false;
+
+    unsigned long _last_reconnect_attempt_ms = 0;
+    unsigned long _last_health_publish_ms = 0;
+};
+
+#endif // HAS_MQTT
+
+#endif // MQTT_MANAGER_H

--- a/src/app/web/network.html
+++ b/src/app/web/network.html
@@ -79,6 +79,39 @@
                     <small>Optional - leave empty if not needed</small>
                 </div>
             </section>
+
+            <!-- MQTT Settings Section (full-width) -->
+            <section class="section" id="mqtt-settings-section">
+                <h2>🏠 MQTT (Home Assistant) (Optional)</h2>
+                <div class="form-group">
+                    <label for="mqtt_host">MQTT Host</label>
+                    <input type="text" id="mqtt_host" name="mqtt_host" maxlength="63" placeholder="e.g. homeassistant.local">
+                    <small>Hostname or IP address of your MQTT broker</small>
+                </div>
+                <div class="form-group">
+                    <label for="mqtt_port">MQTT Port</label>
+                    <input type="number" id="mqtt_port" name="mqtt_port" min="0" max="65535" placeholder="1883">
+                    <small>Defaults to 1883 when empty/0</small>
+                </div>
+                <div class="form-group">
+                    <label for="mqtt_username">MQTT Username</label>
+                    <input type="text" id="mqtt_username" name="mqtt_username" maxlength="31" placeholder="Optional">
+                    <small>Leave empty for anonymous access</small>
+                </div>
+                <div class="form-group">
+                    <label for="mqtt_password">MQTT Password</label>
+                    <input type="password" id="mqtt_password" name="mqtt_password" maxlength="63" placeholder="Optional">
+                    <small>Leave empty to keep existing password</small>
+                </div>
+                <div class="form-group">
+                    <label for="mqtt_interval_seconds">Publish Interval (seconds)</label>
+                    <input type="number" id="mqtt_interval_seconds" name="mqtt_interval_seconds" min="0" max="65535" placeholder="0">
+                    <small>
+                        Modes: leave MQTT Host empty = don't connect. Set MQTT Host + interval 0 = connect (HA discovery + availability) but no periodic health publish. Set MQTT Host + interval &gt; 0 = connect and publish.
+                    </small>
+                </div>
+            </section>
+
             </section>
 
             {{FOOTER}}

--- a/src/version.h
+++ b/src/version.h
@@ -6,7 +6,7 @@
 // Firmware version information
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 0
-#define VERSION_PATCH 15
+#define VERSION_PATCH 16
 
 // Build date (automatically set by compiler)
 #define BUILD_DATE __DATE__


### PR DESCRIPTION
## Summary
Adds MQTT publishing + Home Assistant MQTT Discovery support, plus portal configuration and docs.

## Changes
- MQTT subsystem (`MqttManager`) using PubSubClient with availability (LWT) and retained state publishing
- Home Assistant discovery for device telemetry entities (single JSON state topic + `value_template` per entity)
- New device telemetry module (`device_telemetry`) used by `/api/health` and MQTT payloads
- Network page gains optional MQTT configuration (host/port/user/pass/interval)
- `/api/info` includes `has_mqtt` so UI can hide MQTT settings when compiled out
- New developer documentation: `docs/home-assistant-mqtt.md` (including event-driven sensor pattern)
- Version bump: `0.0.16` + changelog entry

## Notes
- Build verified by user: OK
