### PR TITLE
Add custom partition scheme support (ESP32-C3)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,6 +149,11 @@ jobs:
       run: |
         chmod +x setup.sh
         ./setup.sh
+
+    - name: Install custom partition tables
+      run: |
+        chmod +x tools/install-custom-partitions.sh
+        ./tools/install-custom-partitions.sh
     
     - name: Compile firmware for ${{ matrix.board.name }}
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,11 @@ jobs:
       run: |
         chmod +x setup.sh
         ./setup.sh
+
+    - name: Install custom partition tables
+      run: |
+        chmod +x tools/install-custom-partitions.sh
+        ./tools/install-custom-partitions.sh
     
     - name: Compile firmware for ${{ matrix.board.name }}
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.0.17] - 2025-12-16
+
+### Added
+- Optional custom partition scheme example for ESP32-C3 to increase OTA app space
+  - `partitions/partitions_ota_1_9mb.csv`
+  - Example board target using `PartitionScheme=ota_1_9mb`
+- Installer script to register custom partition schemes into the Arduino ESP32 core: `tools/install-custom-partitions.sh`
+- Custom partitions documentation: `partitions/README.md`
+
+### Changed
+- `setup.sh` now runs the custom partitions installer (when present)
+- CI workflows run the installer before compiling boards that use `PartitionScheme=...`
+
 ## [0.0.16] - 2025-12-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ esp32-template-wifi/
 │   │   └── esp32c3/               # ESP32-C3 Super Mini config example
 │   │       └── board_overrides.h  # Board-specific defines (LED on GPIO8)
 │   └── version.h                  # Firmware version tracking
+├── partitions/                    # Optional custom partition tables (see docs)
+│   └── partitions_ota_1_9mb.csv    # OTA-friendly layout with larger app partitions
 ├── .github/
 │   └── workflows/
 │       └── build.yml              # CI/CD pipeline
@@ -210,8 +212,22 @@ The project supports multiple ESP32 board variants configured in `config.sh`:
 declare -A FQBN_TARGETS=(
     ["esp32:esp32:esp32"]="esp32"                                        # ESP32 Dev Module
     ["esp32:esp32:nologo_esp32c3_super_mini:CDCOnBoot=cdc"]="esp32c3"  # ESP32-C3 Super Mini
+    ["esp32:esp32:nologo_esp32c3_super_mini:CDCOnBoot=cdc,PartitionScheme=ota_1_9mb"]="esp32c3_ota_1_9mb"  # ESP32-C3 Super Mini (custom partitions example)
 )
 ```
+
+### Custom Partition Scheme Example (ESP32-C3)
+
+This template includes an optional custom partition table to increase OTA app partition size on 4MB ESP32-C3 boards.
+
+- Partition CSV: `partitions/partitions_ota_1_9mb.csv`
+- Enabled by using `PartitionScheme=ota_1_9mb` in the board FQBN (see `esp32c3_ota_1_9mb` above)
+- Installed automatically by:
+  - Local dev: `./setup.sh`
+  - CI/CD: GitHub Actions workflows (build + release)
+- Manual (if you changed core versions): `./tools/install-custom-partitions.sh`
+
+**Important:** the first flash after changing the partition table should be done over serial (USB). OTA updates will work normally afterwards.
 
 **Adding/Modifying Boards:**
 

--- a/config.sh
+++ b/config.sh
@@ -39,15 +39,22 @@ PROJECT_DISPLAY_NAME="ESP32 Template"
 # - ESP32-C3, C6, S3: Add `:CDCOnBoot=cdc` to enable USB serial output
 # - ESP32 (classic): No USB-OTG, uses hardware UART - no CDC parameter needed
 # - To check if a board needs CDC: `arduino-cli board details <FQBN> | grep CDCOnBoot`
+
+# Custom Partition Schemes (PartitionScheme):
+# Some ESP32 boards (notably ESP32-C3 “Super Mini” variants) can run out of flash
+# space for OTA-enabled firmware as projects grow.
 #
 # Examples:
 #   ["esp32:esp32:esp32"]="esp32"                                       # Classic ESP32 - hardware UART
 #   ["esp32:esp32:nologo_esp32c3_super_mini:CDCOnBoot=cdc"]="esp32c3"   # C3 with USB CDC enabled
+#   ["esp32:esp32:nologo_esp32c3_super_mini:CDCOnBoot=cdc,PartitionScheme=ota_1_9mb"]="esp32c3_ota_1_9mb"    # C3 with custom partitions example
 #   ["esp32:esp32:dfrobot_firebeetle2_esp32c6:CDCOnBoot=cdc"]="esp32c6" # C6 with USB CDC enabled
 #   ["esp32:esp32:esp32c6:CDCOnBoot=cdc"]="esp32c6supermini"            # C6 with USB CDC enabled (generic Super Mini variant)
+
 declare -A FQBN_TARGETS=(
     ["esp32:esp32:esp32"]="esp32"
     ["esp32:esp32:nologo_esp32c3_super_mini:CDCOnBoot=cdc"]="esp32c3"
+    ["esp32:esp32:nologo_esp32c3_super_mini:CDCOnBoot=cdc,PartitionScheme=ota_1_9mb"]="esp32c3_ota_1_9mb"
 )
 
 # Default board (used when only one board is configured)

--- a/partitions/README.md
+++ b/partitions/README.md
@@ -1,0 +1,77 @@
+# Custom Partition Schemes
+
+This folder contains **optional** custom partition table CSVs that can be enabled via the Arduino ESP32 core’s `PartitionScheme=...` FQBN option.
+
+For the broader build/release context, also see: [docs/build-and-release-process.md](../docs/build-and-release-process.md#custom-partition-schemes)
+
+## How Arduino “PartitionScheme” works (important)
+
+For Arduino ESP32 core builds, using a custom `PartitionScheme` requires **both**:
+
+1. The partition CSV exists inside the installed ESP32 core:
+   - `~/.arduino15/packages/esp32/hardware/esp32/<version>/tools/partitions/`
+2. The scheme is registered in that same core’s `boards.txt` for the target board ID.
+
+This template automates those two steps via: [tools/install-custom-partitions.sh](../tools/install-custom-partitions.sh)
+
+## Adding a new partition scheme (another board)
+
+### 1) Create the partition CSV in this repo
+
+- Add a new CSV under this folder, e.g. `partitions_my_scheme.csv`.
+- The Arduino core will refer to the partition “name” **without** `.csv`.
+- Keep offsets aligned to ESP32 partition rules (commonly: app partitions aligned to `0x10000` / 64KB; `nvs`/`otadata` are usually the exceptions).
+
+Example header (recommended):
+
+```csv
+# Name,    Type, SubType,  Offset,   Size,     Flags
+nvs,       data, nvs,      0x9000,   0x5000,
+otadata,   data, ota,      0xE000,   0x2000,
+app0,      app,  ota_0,    0x10000,  0x1E0000,
+app1,      app,  ota_1,    0x1F0000, 0x1E0000,
+```
+
+### 2) Register the scheme in the ESP32 Arduino core (via the installer script)
+
+Update [tools/install-custom-partitions.sh](../tools/install-custom-partitions.sh) to also install/register your new scheme.
+
+You’ll need:
+
+- **Board ID**: the 3rd segment of the FQBN
+  - Example: `esp32:esp32:nologo_esp32c3_super_mini:...` → board ID is `nologo_esp32c3_super_mini`
+- **Scheme ID**: the string used in `PartitionScheme=<scheme_id>`
+- **Partition filename (no extension)**: what `boards.txt` uses for `build.partitions`
+- **upload.maximum_size**: must match your app partition size (bytes)
+
+The `boards.txt` entries you’re effectively adding look like:
+
+```text
+<BOARD_ID>.menu.PartitionScheme.<SCHEME_ID>=<Human label>
+<BOARD_ID>.menu.PartitionScheme.<SCHEME_ID>.build.partitions=<PARTITION_FILE_NO_EXT>
+<BOARD_ID>.menu.PartitionScheme.<SCHEME_ID>.upload.maximum_size=<MAX_BYTES>
+```
+
+### 3) Add/enable it in `config.sh`
+
+Add a target in [config.sh](../config.sh) that includes your `PartitionScheme` option in the FQBN, for example:
+
+```bash
+["esp32:esp32:<BOARD_ID>:CDCOnBoot=cdc,PartitionScheme=<SCHEME_ID>"]="<board_name>"
+```
+
+### 4) Re-run setup (or installer) and build
+
+After adding or changing partition schemes, run:
+
+```bash
+./setup.sh
+# or (manual)
+./tools/install-custom-partitions.sh
+
+./build.sh <board_name>
+```
+
+## Operational note
+
+After changing the partition table, the **first flash should be done over serial (USB)**. OTA updates will work normally afterwards once the correct partition table is on the device.

--- a/partitions/partitions_ota_1_9mb.csv
+++ b/partitions/partitions_ota_1_9mb.csv
@@ -1,0 +1,17 @@
+# Custom partition table for 4MB flash with OTA support
+#
+# Goal:
+# - Maximize app partition size while keeping dual OTA partitions (app0/app1)
+# - Keep only minimal SPIFFS (rarely used in this template)
+#
+# Notes:
+# - Offsets (except nvs/otadata) must be aligned to 0x10000 (64KB)
+# - The FQBN option `PartitionScheme=ota_1_9mb` must match this filename (without .csv)
+#
+# Name,    Type, SubType,  Offset,   Size,     Flags
+nvs,       data, nvs,      0x9000,   0x5000,
+otadata,   data, ota,      0xE000,   0x2000,
+app0,      app,  ota_0,    0x10000,  0x1E0000,
+app1,      app,  ota_1,    0x1F0000, 0x1E0000,
+coredump,  data, coredump, 0x3D0000, 0x10000,
+spiffs,    data, spiffs,   0x3E0000, 0x20000,

--- a/setup.sh
+++ b/setup.sh
@@ -35,6 +35,18 @@ arduino-cli core update-index
 echo "Installing ESP32 board support..."
 arduino-cli core install esp32:esp32
 
+# Install/register template-provided custom partition schemes.
+#
+# This is required for any board FQBN using `PartitionScheme=...`.
+# Safe to run multiple times (idempotent).
+if [ -f "./tools/install-custom-partitions.sh" ]; then
+    echo "Installing custom partition schemes (optional)..."
+    chmod +x ./tools/install-custom-partitions.sh
+    ./tools/install-custom-partitions.sh || echo "Warning: custom partition install failed (builds using PartitionScheme may fail)"
+else
+    echo "Note: tools/install-custom-partitions.sh not found; skipping custom partitions"
+fi
+
 # Install libraries from arduino-libraries.txt
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIBRARIES_FILE="$SCRIPT_DIR/arduino-libraries.txt"

--- a/src/version.h
+++ b/src/version.h
@@ -6,7 +6,7 @@
 // Firmware version information
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 0
-#define VERSION_PATCH 16
+#define VERSION_PATCH 17
 
 // Build date (automatically set by compiler)
 #define BUILD_DATE __DATE__

--- a/tools/install-custom-partitions.sh
+++ b/tools/install-custom-partitions.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# Install/register custom partition tables into the Arduino ESP32 core.
+#
+# This is intentionally a standalone script so:
+# - Local dev can run: ./tools/install-custom-partitions.sh
+# - setup.sh can call it automatically
+# - CI workflows can call it before compiling boards that use PartitionScheme=...
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(CDPATH="" cd "$SCRIPT_DIR/.." && pwd)"
+
+PARTITION_FILE_SRC="$REPO_ROOT/partitions/partitions_ota_1_9mb.csv"
+PARTITION_SCHEME_ID="ota_1_9mb"
+PARTITION_FILE_BASENAME="partitions_ota_1_9mb.csv"
+PARTITION_NAME_NO_EXT="partitions_ota_1_9mb"
+
+BOARD_ID="nologo_esp32c3_super_mini"
+UPLOAD_MAX_SIZE="1966080"  # 0x1E0000
+
+ESP32_HW_BASE="$HOME/.arduino15/packages/esp32/hardware/esp32"
+
+if [[ ! -f "$PARTITION_FILE_SRC" ]]; then
+  echo "Error: partition file not found: $PARTITION_FILE_SRC" >&2
+  echo "Did you delete or rename the file under partitions/?" >&2
+  exit 1
+fi
+
+if [[ ! -d "$ESP32_HW_BASE" ]]; then
+  echo "Error: ESP32 Arduino core not found at $ESP32_HW_BASE" >&2
+  echo "Run ./setup.sh first to install esp32:esp32." >&2
+  exit 1
+fi
+
+# Pick the latest installed ESP32 core directory.
+# Example: ~/.arduino15/packages/esp32/hardware/esp32/3.0.7
+ESP32_DIR="$(ls -1d "$ESP32_HW_BASE"/*/ 2>/dev/null | sort -V | tail -n 1 || true)"
+ESP32_DIR="${ESP32_DIR%/}"
+
+if [[ -z "$ESP32_DIR" || ! -d "$ESP32_DIR" ]]; then
+  echo "Error: could not locate an installed ESP32 core version under $ESP32_HW_BASE" >&2
+  exit 1
+fi
+
+PARTITION_DIR="$ESP32_DIR/tools/partitions"
+BOARDS_TXT="$ESP32_DIR/boards.txt"
+
+if [[ ! -d "$PARTITION_DIR" ]]; then
+  echo "Error: partition directory not found: $PARTITION_DIR" >&2
+  exit 1
+fi
+
+if [[ ! -f "$BOARDS_TXT" ]]; then
+  echo "Error: boards.txt not found: $BOARDS_TXT" >&2
+  exit 1
+fi
+
+echo "Installing custom partition table into Arduino ESP32 core..."
+echo "- Core:       $ESP32_DIR"
+echo "- Partitions: $PARTITION_DIR"
+
+# 1) Copy partition CSV
+cp "$PARTITION_FILE_SRC" "$PARTITION_DIR/$PARTITION_FILE_BASENAME"
+echo "✓ Installed $PARTITION_FILE_BASENAME"
+
+# 2) Register PartitionScheme in boards.txt (idempotent)
+# We key off the specific menu entry to avoid false positives.
+if grep -q "^${BOARD_ID}\.menu\.PartitionScheme\.${PARTITION_SCHEME_ID}=" "$BOARDS_TXT"; then
+  echo "✓ PartitionScheme '$PARTITION_SCHEME_ID' already registered in boards.txt"
+else
+  {
+    echo ""
+    echo "# Custom OTA partition scheme (installed by $REPO_ROOT/tools/install-custom-partitions.sh)"
+    echo "${BOARD_ID}.menu.PartitionScheme.${PARTITION_SCHEME_ID}=Custom OTA (1.9MB APP×2)"
+    echo "${BOARD_ID}.menu.PartitionScheme.${PARTITION_SCHEME_ID}.build.partitions=${PARTITION_NAME_NO_EXT}"
+    echo "${BOARD_ID}.menu.PartitionScheme.${PARTITION_SCHEME_ID}.upload.maximum_size=${UPLOAD_MAX_SIZE}"
+  } >> "$BOARDS_TXT"
+
+  echo "✓ Registered PartitionScheme '$PARTITION_SCHEME_ID' for board '$BOARD_ID'"
+fi
+
+echo "Done."


### PR DESCRIPTION
Adds an optional custom PartitionScheme example for ESP32-C3 (`ota_1_9mb`) with a repo-contained partitions CSV and an installer that registers the scheme into the Arduino ESP32 core.

Changes:
- New partitions CSV under `partitions/`
- New installer script `tools/install-custom-partitions.sh` (run by `setup.sh` and CI workflows)
- Adds `esp32c3_ota_1_9mb` target example in `config.sh`
- Docs updates + new `partitions/README.md`
- Bump version to `0.0.17` and update `CHANGELOG.md`

Validation:
- Built successfully locally (incl. `esp32c3_ota_1_9mb`).