### PR TITLE
Fix board macro sanitization for valid C++ identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.0.19] - 2025-12-17
+
+### Fixed
+- Fixed board macro sanitization in build system to generate valid C++ identifiers
+  - Board names with special characters (hyphens, dots, etc.) now properly converted to underscores
+  - Macro pattern: `BOARD_<BOARDNAME>` where `<BOARDNAME>` is alphanumeric + underscore only
+  - Example: `cyd2usb-v2` → `BOARD_CYD2USB_V2`, `board.name` → `BOARD_BOARD_NAME`
+  - Resolves compilation errors when using `#if defined(BOARD_xxx)` with hyphenated board names
+- Updated documentation to explain board macro sanitization behavior
+
+---
+
 ## [0.0.18] - 2025-12-17
 
 ### Changed

--- a/build.sh
+++ b/build.sh
@@ -37,7 +37,9 @@ build_board() {
     if [[ -d "$board_override_dir" ]]; then
         echo -e "${YELLOW}Config:    Using board-specific overrides from src/boards/$board_name/${NC}"
         # Add include path and define BOARD_HAS_OVERRIDE to trigger board_overrides.h inclusion
+        # Sanitize board name for valid C++ macro (alphanumeric + underscore only)
         board_macro="BOARD_${board_name^^}"
+        board_macro="${board_macro//[^A-Z0-9_]/_}"
         EXTRA_FLAGS+=(--build-property "compiler.cpp.extra_flags=-I$board_override_dir -D$board_macro -DBOARD_HAS_OVERRIDE=1")
     else
         echo "Config:    Using default configuration"

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -70,7 +70,8 @@ BOARD_PROFILE=psram ./build.sh esp32  # Optional build profile (if defined in co
 - Creates board-specific directories: `./build/esp32/`, `./build/esp32c3/`, etc.
 - Generates `.bin`, `.bootloader.bin`, `.merged.bin`, and `.partitions.bin` files per board
 - If `src/boards/<board>/` exists, adds it to include path and defines:
-    - `BOARD_<BOARDNAME>` (e.g., `BOARD_ESP32C3`)
+    - `BOARD_<BOARDNAME>` - Board name sanitized to valid C++ macro (alphanumeric + underscore only)
+      - Examples: `cyd2usb-v2` → `BOARD_CYD2USB_V2`, `esp32c3` → `BOARD_ESP32C3`
     - `BOARD_HAS_OVERRIDE` (triggers inclusion of `board_overrides.h`)
 
 **Build Output Structure:**

--- a/src/version.h
+++ b/src/version.h
@@ -6,7 +6,7 @@
 // Firmware version information
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 0
-#define VERSION_PATCH 18
+#define VERSION_PATCH 19
 
 // Build date (automatically set by compiler)
 #define BUILD_DATE __DATE__


### PR DESCRIPTION
## Summary
Fixes build system to generate valid C++ macro names from board names containing special characters (hyphens, dots, etc.).

## Problem
Board names with special characters (e.g., `cyd2usb-v2`, `board.name`) generate invalid C++ macros like `BOARD_CYD2USB-V2` which fail in `#if defined()` checks.

## Solution
Enhanced board macro sanitization in `build.sh` to replace all non-alphanumeric characters with underscores:
- `cyd2usb-v2` → `BOARD_CYD2USB_V2`
- `board.name` → `BOARD_BOARD_NAME`

## Changes
- **build.sh**: Enhanced sanitization using `${board_macro//[^A-Z0-9_]/_}` pattern
- **docs/scripts.md**: Added documentation explaining macro sanitization behavior with examples
- **src/version.h**: Bumped patch version 0.0.18 → 0.0.19
- **CHANGELOG.md**: Added release notes for v0.0.19

## Testing
- ✅ Builds successfully for all configured boards (esp32, cyd2usb-v2, cyd2usb-v3)
- ✅ Board-specific macros correctly defined and usable in conditional compilation

## Impact
- Infrastructure improvement that enables support for hyphenated board names
- No breaking changes to existing functionality
- Required for upcoming display support feature (CYD boards)