### PR TITLE
Improve OTA download robustness (v0.0.41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.41] - 2026-01-17
+
+### Added
+- OTA download retry with fresh connections plus richer failure logging (HTTP error string, WiFi status/RSSI)
+
 ## [0.0.40] - 2026-01-17
 
 ### Added

--- a/src/version.h
+++ b/src/version.h
@@ -6,7 +6,7 @@
 // Firmware version information
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 0
-#define VERSION_PATCH 40
+#define VERSION_PATCH 41
 
 // Build date (automatically set by compiler)
 #define BUILD_DATE __DATE__


### PR DESCRIPTION
## Summary
- add OTA download retry with fresh connections and better failure logging
- bump firmware patch version to 0.0.41 with changelog

## Testing
- Device OTA update (reported by author)