### PR TITLE
Fix compile flags report to honor config.project.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.43] - 2026-01-19
+
+### Changed
+- Compile-time flags report now honors config.project.sh and fails fast when it exists but defines no boards
+- build.sh now checks and updates docs/compile-time-flags.md during builds and reports whether it changed
+
 ## [0.0.42] - 2026-01-17
 
 ### Added

--- a/src/version.h
+++ b/src/version.h
@@ -6,7 +6,7 @@
 // Firmware version information
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 0
-#define VERSION_PATCH 42
+#define VERSION_PATCH 43
 
 // Build date (automatically set by compiler)
 #define BUILD_DATE __DATE__

--- a/tools/compile_flags_report.py
+++ b/tools/compile_flags_report.py
@@ -57,8 +57,13 @@ def parse_boards_from_config_files(config_sh: Path, config_project_sh: Optional[
     boards = parse_boards_from_config_sh(config_sh)
     if config_project_sh and config_project_sh.exists():
         project_boards = parse_boards_from_config_sh(config_project_sh)
-        if project_boards:
-            return project_boards
+        if not project_boards:
+            raise SystemExit(
+                f"{config_project_sh} exists but no boards were found. "
+                "Ensure it declares FQBN_TARGETS entries like [\"board\"]=\"fqbn\", "
+                "or remove/rename the file."
+            )
+        return project_boards
     return boards
 
 


### PR DESCRIPTION
## Summary
- honor config.project.sh in compile_flags_report.py and fail fast when it exists but defines no boards
- build.sh now checks/updates docs/compile-time-flags.md and reports whether it changed
- bump version to 0.0.43 and update CHANGELOG

## Testing
- not run (build skipped)
