### PR TITLE
Fix AXS15231B touch interrupt handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.45] - 2026-01-29
+
+### Fixed
+- AXS15231B touch: avoid invalid INT pin crashes and add polling fallback when INT is not wired
+
 ## [0.0.44] - 2026-01-24
 
 ### Changed

--- a/src/app/drivers/axs15231b/vendor/AXS15231B_touch.h
+++ b/src/app/drivers/axs15231b/vendor/AXS15231B_touch.h
@@ -8,6 +8,8 @@ class AXS15231B_Touch {
 private:
     uint8_t scl, sda, int_pin, addr, rotation;
 
+    bool use_interrupt = true;
+
     volatile bool touch_int = false;
     static AXS15231B_Touch* instance;
 

--- a/src/app/drivers/axs15231b_touch_driver.cpp
+++ b/src/app/drivers/axs15231b_touch_driver.cpp
@@ -29,9 +29,13 @@ void AXS15231B_TouchDriver::init() {
     // Create touch instance with I2C pins and interrupt
     // From sample: AXS15231B_Touch(SCL, SDA, INT, ADDR, rotation)
     uint8_t int_pin = 3;  // Default from sample
+    bool use_polling = false;
     #ifdef TOUCH_INT
     if (TOUCH_INT >= 0) {
         int_pin = TOUCH_INT;
+    } else {
+        int_pin = 0xFF;
+        use_polling = true;
     }
     #endif
     
@@ -51,7 +55,11 @@ void AXS15231B_TouchDriver::init() {
     // Enable offset correction (from sample)
     touch->enOffsetCorrection(true);
     
-    LOGI("AXS15231B", "Touch controller initialized");
+    if (use_polling) {
+        LOGI("AXS15231B", "Touch controller initialized (polling mode)");
+    } else {
+        LOGI("AXS15231B", "Touch controller initialized");
+    }
     #else
     LOGE("AXS15231B", "Touch I2C pins not defined in board_config.h");
     #endif

--- a/src/version.h
+++ b/src/version.h
@@ -6,7 +6,7 @@
 // Firmware version information
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 0
-#define VERSION_PATCH 44
+#define VERSION_PATCH 45
 
 // Build date (automatically set by compiler)
 #define BUILD_DATE __DATE__


### PR DESCRIPTION
## Summary
- guard AXS15231B interrupt attach for invalid INT pins
- add polling fallback when INT is not wired
- bump version to 0.0.45 and update changelog

## Testing
- ./build.sh jc3248w535