### PR TITLE
Release v0.0.58

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,8 +147,17 @@ jobs:
           exit 1
         fi
 
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Run host-native unit tests
+      run: bash tests/run_tests.sh
+
   build:
-    needs: [prepare-matrix, compile-flags-doc]
+    needs: [prepare-matrix, compile-flags-doc, unit-tests]
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.58] - 2026-03-23
+
+### Added
+- OTA rollback protection: `esp_ota_mark_app_valid_cancel_rollback()` called at end of `setup()` — prevents bootloader from reverting firmware after a clean startup
+- Heap integrity check in 60-second heartbeat: `heap_caps_check_integrity_all()` catches heap corruption early
+- `monitor.sh --log` / `--log=<file>` flag: serial output is simultaneously saved to a timestamped log file via `tee`
+- `i2c_bus.cpp/h`: lightweight FreeRTOS mutex wrapper for shared I2C bus access across tasks (`i2c_bus_init`, `i2c_bus_lock`, `i2c_bus_unlock`)
+- MQTT subscription infrastructure in `MqttManager`: `addSubscription(topic, handler)` registers per-topic callbacks; handlers are re-subscribed automatically after each reconnect
+- `mqtt_wake.cpp/h`: subscribes to a configurable MQTT topic and wakes the screen saver when an `ON`/`1`/`true` payload is received
+- `DeviceConfig.screen_saver_wake_topic` field (64-byte, `#if HAS_MQTT && HAS_DISPLAY`): persisted in NVS, exposed in web portal Home page and REST API
+- Host-native unit test infrastructure in `tests/`: `run_tests.sh`, stub headers (`Arduino.h`, `log_manager.h`, `board_config.h`), and `stubs.cpp`; 40 test cases covering `power_config` parse functions and `config_manager_sanitize_device_name`
+- Unit test CI step in `.github/workflows/build.yml`: `unit-tests` job runs before firmware builds; firmware build now depends on tests passing
+- `DisplayManager::goBack()` and `display_manager_go_back()` C-API: navigate to the previous screen in an 8-deep history stack
+- WiFi resilience: gateway liveness watchdog using `esp_ping` — forces reconnect after 3 consecutive ping failures even when `WiFi.status()` still reports connected
+
+### Changed
+- `DisplayManager` navigation history replaced single `previousScreen` pointer with an 8-entry `screenHistory` stack; splash screen is excluded from history
+- ESP32-P4 WiFi startup: replaced fixed `delay(5000)` with a MAC-address polling loop (250 ms poll, 8 s cap) to reduce boot time when ESP-Hosted link is fast
+- ESP32-P4 WiFi retry delay reduced from 2000 ms to 500 ms between reconnect attempts
+- `wifi_manager_watchdog` refactored: status-lost path and ping-fail path share a single reconnect+mDNS code block; `g_last_wifi_check_ms` updated at entry to prevent overlapping checks
+
 ## [0.0.57] - 2026-02-27
 
 ### Added

--- a/docs/compile-time-flags.md
+++ b/docs/compile-time-flags.md
@@ -284,6 +284,7 @@ Legend: ✅ = enabled/true, blank = disabled/false, ? = unknown/undefined
   - src/app/app.ino
   - src/app/board_config.h
   - src/app/config_manager.cpp
+  - src/app/config_manager.h
   - src/app/device_telemetry.cpp
   - src/app/duty_cycle.cpp
   - src/app/ha_discovery.cpp
@@ -297,6 +298,7 @@ Legend: ✅ = enabled/true, blank = disabled/false, ? = unknown/undefined
   - src/app/sensors/ld2410_out_sensor.cpp
   - src/app/sensors/sensor_manager.cpp
   - src/app/sensors/sensor_manager.h
+  - src/app/web_portal_config.cpp
 - **HAS_SENSOR_BME280**
   - src/app/board_config.h
   - src/app/sensors.cpp

--- a/docs/compile-time-flags.md
+++ b/docs/compile-time-flags.md
@@ -270,6 +270,8 @@ Legend: ✅ = enabled/true, blank = disabled/false, ? = unknown/undefined
   - src/app/display_manager.cpp
   - src/app/ha_discovery.cpp
   - src/app/lv_conf.h
+  - src/app/mqtt_wake.cpp
+  - src/app/mqtt_wake.h
   - src/app/screen_saver_manager.cpp
   - src/app/screen_saver_manager.h
   - src/app/screens.cpp
@@ -291,6 +293,8 @@ Legend: ✅ = enabled/true, blank = disabled/false, ? = unknown/undefined
   - src/app/ha_discovery.h
   - src/app/mqtt_manager.cpp
   - src/app/mqtt_manager.h
+  - src/app/mqtt_wake.cpp
+  - src/app/mqtt_wake.h
   - src/app/sensors/bme280_sensor.cpp
   - src/app/sensors/bme280_sensor.h
   - src/app/sensors/dummy_sensor.cpp

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -274,14 +274,18 @@ This script automates both steps.
 
 **Usage:**
 ```bash
-./monitor.sh                  # Auto-detects port, 115200 baud
-./monitor.sh /dev/ttyUSB0     # Custom port, default baud
-./monitor.sh /dev/ttyUSB0 9600 # Custom port and baud rate
+./monitor.sh                          # Auto-detects port, 115200 baud
+./monitor.sh /dev/ttyUSB0             # Custom port, default baud
+./monitor.sh /dev/ttyUSB0 9600        # Custom port and baud rate
+./monitor.sh --log                    # Log to auto-named file (monitor_YYYYMMDD_HHMMSS.log)
+./monitor.sh --log=session.log        # Log to a specific file
+./monitor.sh /dev/ttyUSB0 --log       # Combine port selection with logging
 ```
 
 **What it does:**
 - Opens serial monitor connection to ESP32
 - Displays real-time output from `Serial.print()` statements
+- When `--log` is specified, output is also saved to a file via `tee`
 - Press `Ctrl+C` to exit
 
 **Requirements:** 

--- a/monitor.sh
+++ b/monitor.sh
@@ -12,6 +12,24 @@ source "$SCRIPT_DIR/config.sh"
 # Configuration
 BAUD="${2:-115200}"         # Default baud rate, can be overridden by second argument
 
+# Parse --log / --log=<file> from arguments
+LOG_FILE=""
+POSITIONAL=()
+for arg in "$@"; do
+    case "$arg" in
+        --log=*)
+            LOG_FILE="${arg#--log=}"
+            ;;
+        --log)
+            LOG_FILE="monitor_$(date '+%Y%m%d_%H%M%S').log"
+            ;;
+        *)
+            POSITIONAL+=("$arg")
+            ;;
+    esac
+done
+set -- "${POSITIONAL[@]}"
+
 # Get arduino-cli path
 ARDUINO_CLI=$(find_arduino_cli)
 
@@ -21,8 +39,8 @@ if [ -z "$1" ]; then
         echo -e "${GREEN}Auto-detected port: $PORT${NC}"
     else
         echo -e "${RED}Error: No serial port detected${NC}"
-        echo "Usage: $0 [PORT] [BAUD]"
-        echo "Example: $0 /dev/ttyUSB0 115200"
+        echo "Usage: $0 [PORT] [BAUD] [--log[=file.log]]"
+        echo "Example: $0 /dev/ttyUSB0 115200 --log"
         exit 1
     fi
 else
@@ -34,8 +52,15 @@ echo -e "${CYAN}=== ESP32 Serial Monitor ===${NC}"
 # Display connection info
 echo "Connecting to: $PORT"
 echo "Baud rate: $BAUD"
+if [ -n "$LOG_FILE" ]; then
+    echo -e "${YELLOW}Logging to: $LOG_FILE${NC}"
+fi
 echo -e "${YELLOW}Press Ctrl+C to exit${NC}"
 echo "---"
 
-# Start serial monitor
-"$ARDUINO_CLI" monitor -p "$PORT" -c baudrate="$BAUD"
+# Start serial monitor (with optional logging via tee)
+if [ -n "$LOG_FILE" ]; then
+    "$ARDUINO_CLI" monitor -p "$PORT" -c baudrate="$BAUD" | tee "$LOG_FILE"
+else
+    "$ARDUINO_CLI" monitor -p "$PORT" -c baudrate="$BAUD"
+fi

--- a/src/app/app.ino
+++ b/src/app/app.ino
@@ -16,10 +16,12 @@
 #include "health_history.h"
 #endif
 #include <WiFi.h>
+#include <esp_ota_ops.h>
 
 #if HAS_DISPLAY
 #include "display_manager.h"
 #include "screen_saver_manager.h"
+#include "mqtt_wake.h"
 #endif
 
 #if HAS_TOUCH
@@ -275,8 +277,16 @@ void setup()
 	mqtt_manager.begin(&device_config, device_config.device_name, sanitized);
 	#endif
 
+	#if HAS_MQTT && HAS_DISPLAY
+	// Register MQTT screen saver wake subscription if topic is configured
+	mqtt_wake_begin(&mqtt_manager, device_config.screen_saver_wake_topic);
+	#endif
+
 	last_heartbeat_ms = millis();
 	LOGI("Main", "Setup complete");
+
+	// Mark firmware as valid to prevent bootloader rollback after OTA.
+	esp_ota_mark_app_valid_cancel_rollback();
 
 	// Snapshot after all subsystems are initialized.
 	device_telemetry_log_memory_snapshot("setup");
@@ -360,6 +370,9 @@ void loop()
 		}
 
 		last_heartbeat_ms = current_ms;
+
+		// Periodic heap integrity check — detects buffer overruns close to when they occur.
+		heap_caps_check_integrity_all(true);
 	}
 
 	delay(10);

--- a/src/app/config_manager.cpp
+++ b/src/app/config_manager.cpp
@@ -53,6 +53,7 @@
 #define KEY_SCREEN_SAVER_FADE_OUT "ss_fo"
 #define KEY_SCREEN_SAVER_FADE_IN "ss_fi"
 #define KEY_SCREEN_SAVER_WAKE_TOUCH "ss_wt"
+#define KEY_SCREEN_SAVER_WAKE_TOPIC "ss_wk_tp"
 #endif
 #define KEY_MAGIC          "magic"
 
@@ -253,6 +254,9 @@ bool config_manager_load(DeviceConfig *config) {
 		#else
 		config->screen_saver_wake_on_touch = preferences.getBool(KEY_SCREEN_SAVER_WAKE_TOUCH, false);
 		#endif
+		#if HAS_MQTT
+		strlcpy(config->screen_saver_wake_topic, preferences.getString(KEY_SCREEN_SAVER_WAKE_TOPIC, "").c_str(), sizeof(config->screen_saver_wake_topic));
+		#endif
 		#endif
 		
 		config->magic = magic;
@@ -339,6 +343,9 @@ bool config_manager_save(const DeviceConfig *config) {
 		preferences.putUShort(KEY_SCREEN_SAVER_FADE_OUT, config->screen_saver_fade_out_ms);
 		preferences.putUShort(KEY_SCREEN_SAVER_FADE_IN, config->screen_saver_fade_in_ms);
 		preferences.putBool(KEY_SCREEN_SAVER_WAKE_TOUCH, config->screen_saver_wake_on_touch);
+		#if HAS_MQTT
+		preferences.putString(KEY_SCREEN_SAVER_WAKE_TOPIC, config->screen_saver_wake_topic);
+		#endif
 		#endif
 		
 		// Save magic number last (indicates valid config)
@@ -444,5 +451,11 @@ void config_manager_print(const DeviceConfig *config) {
 #else
 		// MQTT config can still exist in NVS, but the firmware has MQTT support compiled out.
 		LOGI("Config", "MQTT: disabled (feature not compiled into firmware)");
+#endif
+
+#if HAS_DISPLAY && HAS_MQTT
+		if (strlen(config->screen_saver_wake_topic) > 0) {
+				LOGI("Config", "Screen saver wake topic: %s", config->screen_saver_wake_topic);
+		}
 #endif
 }

--- a/src/app/config_manager.h
+++ b/src/app/config_manager.h
@@ -98,6 +98,10 @@ struct DeviceConfig {
 		uint16_t screen_saver_fade_out_ms;       // default 800
 		uint16_t screen_saver_fade_in_ms;        // default 400
 		bool screen_saver_wake_on_touch;         // default true (when HAS_TOUCH)
+#if HAS_MQTT
+		// Screen saver wake via MQTT: subscribe to this topic and wake on ON/1/true payload
+		char screen_saver_wake_topic[64];        // default ""
+#endif
 #endif
 		
 		// Validation flag (magic number to detect valid config)

--- a/src/app/display_manager.cpp
+++ b/src/app/display_manager.cpp
@@ -38,7 +38,7 @@ static uint16_t g_perf_frames_in_window = 0;
 DisplayManager* displayManager = nullptr;
 
 DisplayManager::DisplayManager(DeviceConfig* cfg) 
-		: driver(nullptr), display(nullptr), config(cfg), currentScreen(nullptr), screenHistory{}, screenHistorySize(0), pendingScreen(nullptr), 
+		: driver(nullptr), display(nullptr), config(cfg), currentScreen(nullptr), screenHistory{}, screenHistorySize(0), pendingScreen(nullptr), pendingScreenSkipHistory(false), 
 			infoScreen(cfg, this), testScreen(this), fpsScreen(this),
 							lvglTaskHandle(nullptr), lvglTaskAlloc{}, lvglMutex(nullptr),
 						presentTaskHandle(nullptr), presentTaskAlloc{}, presentSem(nullptr), sharedLvTimerUs(0),
@@ -240,12 +240,14 @@ void DisplayManager::lvglTask(void* pvParameter) {
 				// Process pending screen switch (deferred from external calls)
 				if (mgr->pendingScreen) {
 						Screen* target = mgr->pendingScreen;
+						bool skipHistory = mgr->pendingScreenSkipHistory;
 						if (mgr->currentScreen) {
 								mgr->currentScreen->hide();
 						}
 
-						// Push current screen to history (skip splash; it's boot-only)
-						if (mgr->currentScreen && mgr->currentScreen != &mgr->splashScreen) {
+						// Push current screen to history unless this is a back-navigation
+						// or the current screen is splash (boot-only, excluded from history).
+						if (!skipHistory && mgr->currentScreen && mgr->currentScreen != &mgr->splashScreen) {
 								if (mgr->screenHistorySize < 8) {
 										mgr->screenHistory[mgr->screenHistorySize++] = mgr->currentScreen;
 								} else {
@@ -256,8 +258,9 @@ void DisplayManager::lvglTask(void* pvParameter) {
 						}
 
 						mgr->currentScreen = target;
-						mgr->currentScreen->show();
 						mgr->pendingScreen = nullptr;
+						mgr->pendingScreenSkipHistory = false;
+						mgr->currentScreen->show();
 
 						// Reset LVGL input device state so leftover PRESSED from the
 						// previous screen doesn't fire a phantom CLICKED on the new screen.
@@ -611,6 +614,7 @@ void DisplayManager::goBack() {
 		screenHistory[screenHistorySize] = nullptr;
 		if (prev) {
 				pendingScreen = prev;
+				pendingScreenSkipHistory = true; // don't push current screen back onto history
 				LOGI("Display", "Queued go-back (history depth now %d)", screenHistorySize);
 		}
 }

--- a/src/app/display_manager.cpp
+++ b/src/app/display_manager.cpp
@@ -38,7 +38,7 @@ static uint16_t g_perf_frames_in_window = 0;
 DisplayManager* displayManager = nullptr;
 
 DisplayManager::DisplayManager(DeviceConfig* cfg) 
-		: driver(nullptr), display(nullptr), config(cfg), currentScreen(nullptr), previousScreen(nullptr), pendingScreen(nullptr), 
+		: driver(nullptr), display(nullptr), config(cfg), currentScreen(nullptr), screenHistory{}, screenHistorySize(0), pendingScreen(nullptr), 
 			infoScreen(cfg, this), testScreen(this), fpsScreen(this),
 							lvglTaskHandle(nullptr), lvglTaskAlloc{}, lvglMutex(nullptr),
 						presentTaskHandle(nullptr), presentTaskAlloc{}, presentSem(nullptr), sharedLvTimerUs(0),
@@ -244,7 +244,17 @@ void DisplayManager::lvglTask(void* pvParameter) {
 								mgr->currentScreen->hide();
 						}
 
-						mgr->previousScreen = mgr->currentScreen;
+						// Push current screen to history (skip splash; it's boot-only)
+						if (mgr->currentScreen && mgr->currentScreen != &mgr->splashScreen) {
+								if (mgr->screenHistorySize < 8) {
+										mgr->screenHistory[mgr->screenHistorySize++] = mgr->currentScreen;
+								} else {
+										// Stack full: discard oldest entry
+										memmove(&mgr->screenHistory[0], &mgr->screenHistory[1], 7 * sizeof(Screen*));
+										mgr->screenHistory[7] = mgr->currentScreen;
+								}
+						}
+
 						mgr->currentScreen = target;
 						mgr->currentScreen->show();
 						mgr->pendingScreen = nullptr;
@@ -592,6 +602,19 @@ void DisplayManager::showTest() {
 		LOGI("Display", "Queued switch to TestScreen");
 }
 
+void DisplayManager::goBack() {
+		if (screenHistorySize == 0) {
+				LOGD("Display", "goBack: history empty");
+				return;
+		}
+		Screen* prev = screenHistory[--screenHistorySize];
+		screenHistory[screenHistorySize] = nullptr;
+		if (prev) {
+				pendingScreen = prev;
+				LOGI("Display", "Queued go-back (history depth now %d)", screenHistorySize);
+		}
+}
+
 void DisplayManager::setSplashStatus(const char* text) {
 		// If called before the LVGL task exists (during early setup), update directly.
 		// Otherwise, defer to the LVGL task to avoid cross-task LVGL calls.
@@ -664,6 +687,12 @@ void display_manager_show_info() {
 void display_manager_show_test() {
 		if (displayManager) {
 				displayManager->showTest();
+		}
+}
+
+void display_manager_go_back() {
+		if (displayManager) {
+				displayManager->goBack();
 		}
 }
 

--- a/src/app/display_manager.h
+++ b/src/app/display_manager.h
@@ -74,7 +74,8 @@ private:
 		
 		// Screen management
 		Screen* currentScreen;
-		Screen* previousScreen;  // Track previous screen for return navigation
+		Screen* screenHistory[8];  // Navigation history stack (excludes splash)
+		uint8_t screenHistorySize; // Number of entries in history stack
 		Screen* pendingScreen;   // Deferred screen switch (processed in lvglTask)
 
 		// Defer small LVGL UI updates (like splash status) to the LVGL task.
@@ -135,6 +136,10 @@ public:
 		void showSplash();
 		void showInfo();
 		void showTest();
+
+		// Navigate back to the previous screen in the history stack.
+		// Does nothing if there is no history.
+		void goBack();
 		
 		// Screen selection by ID (thread-safe, returns true if found)
 		bool showScreen(const char* screen_id);
@@ -181,6 +186,7 @@ void display_manager_init(DeviceConfig* config);
 void display_manager_show_splash();
 void display_manager_show_info();
 void display_manager_show_test();
+void display_manager_go_back();
 void display_manager_show_screen(const char* screen_id, bool* success);  // success is optional output
 const char* display_manager_get_current_screen_id();
 const ScreenInfo* display_manager_get_available_screens(size_t* count);

--- a/src/app/display_manager.h
+++ b/src/app/display_manager.h
@@ -74,9 +74,10 @@ private:
 		
 		// Screen management
 		Screen* currentScreen;
-		Screen* screenHistory[8];  // Navigation history stack (excludes splash)
-		uint8_t screenHistorySize; // Number of entries in history stack
-		Screen* pendingScreen;   // Deferred screen switch (processed in lvglTask)
+		Screen* screenHistory[8];    // Navigation history stack (excludes splash)
+		uint8_t screenHistorySize;   // Number of entries in history stack
+		Screen* pendingScreen;       // Deferred screen switch (processed in lvglTask)
+		bool pendingScreenSkipHistory; // When true, the switch does not push to history (used by goBack)
 
 		// Defer small LVGL UI updates (like splash status) to the LVGL task.
 		char pendingSplashStatus[96];

--- a/src/app/i2c_bus.cpp
+++ b/src/app/i2c_bus.cpp
@@ -1,0 +1,24 @@
+#include "i2c_bus.h"
+
+#include "log_manager.h"
+
+static SemaphoreHandle_t g_i2c_mutex = nullptr;
+
+void i2c_bus_init() {
+	if (!g_i2c_mutex) {
+		g_i2c_mutex = xSemaphoreCreateMutex();
+		if (!g_i2c_mutex) {
+			LOGE("I2C", "Failed to create bus mutex");
+		}
+	}
+}
+
+bool i2c_bus_lock(TickType_t timeout) {
+	if (!g_i2c_mutex) return true; // mutex not initialized, allow through
+	return xSemaphoreTake(g_i2c_mutex, timeout) == pdTRUE;
+}
+
+void i2c_bus_unlock() {
+	if (!g_i2c_mutex) return;
+	xSemaphoreGive(g_i2c_mutex);
+}

--- a/src/app/i2c_bus.h
+++ b/src/app/i2c_bus.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "board_config.h"
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+// Shared mutex for Wire bus 0 (I2C) thread safety.
+// Use when multiple peripherals share the same I2C bus and are accessed
+// from different FreeRTOS tasks (e.g., touch controller + other I2C device).
+
+// Create the Wire bus 0 mutex. Call once during setup() before any
+// multi-task I2C usage begins.
+void i2c_bus_init();
+
+// Acquire exclusive access to Wire bus 0.
+// Returns true if the lock was obtained within the timeout (default 50 ms).
+bool i2c_bus_lock(TickType_t timeout = pdMS_TO_TICKS(50));
+
+// Release Wire bus 0 access.
+void i2c_bus_unlock();

--- a/src/app/mqtt_manager.cpp
+++ b/src/app/mqtt_manager.cpp
@@ -12,6 +12,36 @@
 
 MqttManager::MqttManager() : _client(_net) {}
 
+// Global pointer for the PubSubClient callback (only one MqttManager instance exists).
+static MqttManager *g_instance = nullptr;
+
+void MqttManager::globalMessageCallback(char *topic, uint8_t *payload, unsigned int len) {
+		if (!g_instance) return;
+		for (uint8_t i = 0; i < g_instance->_subscription_count; i++) {
+				if (strcmp(g_instance->_subscriptions[i].topic, topic) == 0) {
+						g_instance->_subscriptions[i].handler(topic, payload, len);
+				}
+		}
+}
+
+void MqttManager::resubscribeAll() {
+		for (uint8_t i = 0; i < _subscription_count; i++) {
+				_client.subscribe(_subscriptions[i].topic);
+		}
+}
+
+bool MqttManager::addSubscription(const char *topic, MessageHandler handler) {
+		if (!topic || !handler) return false;
+		if (_subscription_count >= MQTT_MAX_SUBSCRIPTIONS) {
+				LOGW("MQTT", "Subscription limit reached (%d)", MQTT_MAX_SUBSCRIPTIONS);
+				return false;
+		}
+		strlcpy(_subscriptions[_subscription_count].topic, topic, sizeof(_subscriptions[0].topic));
+		_subscriptions[_subscription_count].handler = handler;
+		_subscription_count++;
+		return true;
+}
+
 void MqttManager::begin(const DeviceConfig *config, const char *friendly_name, const char *sanitized_name) {
 		_config = config;
 
@@ -32,6 +62,8 @@ void MqttManager::begin(const DeviceConfig *config, const char *friendly_name, c
 		snprintf(_health_state_topic, sizeof(_health_state_topic), "%s/health/state", _base_topic);
 
 		_client.setBufferSize(MQTT_MAX_PACKET_SIZE);
+		_client.setCallback(MqttManager::globalMessageCallback);
+		g_instance = this;
 
 		_discovery_published_this_boot = false;
 		_last_reconnect_attempt_ms = 0;
@@ -216,6 +248,7 @@ void MqttManager::ensureConnected() {
 
 		if (connected) {
 				LOGI("MQTT", "Connected");
+				resubscribeAll();
 				if (!duty_cycle) {
 						publishAvailability(true);
 				}

--- a/src/app/mqtt_manager.h
+++ b/src/app/mqtt_manager.h
@@ -39,6 +39,13 @@ public:
 		// Immediate publish API (topic is full topic string)
 		bool publishImmediate(const char *topic, const char *payload, bool retained);
 
+		// Subscription API: register a handler for an MQTT topic.
+		// Up to MQTT_MAX_SUBSCRIPTIONS handlers can be registered.
+		// Handlers are re-subscribed automatically after each reconnect.
+		static constexpr uint8_t MQTT_MAX_SUBSCRIPTIONS = 8;
+		typedef void (*MessageHandler)(const char *topic, const uint8_t *payload, unsigned int len);
+		bool addSubscription(const char *topic, MessageHandler handler);
+
 		// Topic helpers
 		const char *baseTopic() const { return _base_topic; }
 		const char *availabilityTopic() const { return _availability_topic; }
@@ -72,6 +79,17 @@ private:
 
 		unsigned long _last_reconnect_attempt_ms = 0;
 		unsigned long _last_health_publish_ms = 0;
+
+		// Subscription registry
+		struct Subscription {
+				char topic[128];
+				MessageHandler handler;
+		};
+		Subscription _subscriptions[MQTT_MAX_SUBSCRIPTIONS] = {};
+		uint8_t _subscription_count = 0;
+
+		void resubscribeAll();
+		static void globalMessageCallback(char *topic, uint8_t *payload, unsigned int len);
 };
 
 // Global instance (defined in app.ino)

--- a/src/app/mqtt_wake.cpp
+++ b/src/app/mqtt_wake.cpp
@@ -1,0 +1,36 @@
+#include "mqtt_wake.h"
+
+#if HAS_MQTT && HAS_DISPLAY
+
+#include "screen_saver_manager.h"
+#include "log_manager.h"
+
+#include <string.h>
+#include <strings.h>
+
+static bool isWakePayload(const uint8_t *payload, unsigned int len) {
+		char buf[8];
+		unsigned int copy = len < sizeof(buf) - 1 ? len : sizeof(buf) - 1;
+		memcpy(buf, payload, copy);
+		buf[copy] = '\0';
+		return strcasecmp(buf, "ON") == 0
+		       || strcmp(buf, "1") == 0
+		       || strcasecmp(buf, "true") == 0;
+}
+
+static void onWakeMessage(const char *topic, const uint8_t *payload, unsigned int len) {
+		(void)topic;
+		if (isWakePayload(payload, len)) {
+				LOGI("MqttWake", "Wake triggered by MQTT");
+				screen_saver_manager_notify_activity(true);
+		}
+}
+
+void mqtt_wake_begin(MqttManager *mqtt, const char *topic) {
+		if (!mqtt || !topic || strlen(topic) == 0) return;
+		if (mqtt->addSubscription(topic, onWakeMessage)) {
+				LOGI("MqttWake", "Subscribed to wake topic: %s", topic);
+		}
+}
+
+#endif // HAS_MQTT && HAS_DISPLAY

--- a/src/app/mqtt_wake.h
+++ b/src/app/mqtt_wake.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "board_config.h"
+
+#if HAS_MQTT && HAS_DISPLAY
+
+#include "mqtt_manager.h"
+
+// Subscribes to the configured screen saver wake topic and wakes the display
+// when a payload of "ON", "1", or "true" (case-insensitive) is received.
+//
+// Call mqtt_wake_begin() once after MqttManager::begin() if a wake topic is configured.
+// No per-loop call needed — the wake is handled by the MQTT callback.
+
+void mqtt_wake_begin(MqttManager *mqtt, const char *topic);
+
+#endif // HAS_MQTT && HAS_DISPLAY

--- a/src/app/web/home.html
+++ b/src/app/web/home.html
@@ -200,6 +200,13 @@
                     <small>Only applies to touch-enabled boards.</small>
                 </div>
 
+                <div class="form-group">
+                    <label for="screen_saver_wake_topic">MQTT Wake Topic</label>
+                    <input type="text" id="screen_saver_wake_topic" name="screen_saver_wake_topic"
+                           maxlength="63" placeholder="e.g. home/screen/wake">
+                    <small>Optional MQTT topic. Sending ON, 1, or true wakes the screen saver. Requires MQTT to be configured.</small>
+                </div>
+
                 <div class="form-group" id="screen-selection-group" style="display:none;">
                     <label for="screen_selection">
                         Current Screen

--- a/src/app/web/portal.js
+++ b/src/app/web/portal.js
@@ -657,6 +657,7 @@ async function loadConfig() {
         setValueIfExists('screen_saver_fade_out_ms', config.screen_saver_fade_out_ms);
         setValueIfExists('screen_saver_fade_in_ms', config.screen_saver_fade_in_ms);
         setCheckedIfExists('screen_saver_wake_on_touch', config.screen_saver_wake_on_touch);
+        setValueIfExists('screen_saver_wake_topic', config.screen_saver_wake_topic);
         
         // Hide loading overlay (silent load)
         const overlay = document.getElementById('form-loading-overlay');
@@ -701,7 +702,8 @@ function extractFormFields(formData) {
                     'mqtt_publish_scope',
                     'basic_auth_enabled', 'basic_auth_username', 'basic_auth_password',
                     'backlight_brightness',
-                    'screen_saver_enabled', 'screen_saver_timeout_seconds', 'screen_saver_fade_out_ms', 'screen_saver_fade_in_ms', 'screen_saver_wake_on_touch'];
+                    'screen_saver_enabled', 'screen_saver_timeout_seconds', 'screen_saver_fade_out_ms', 'screen_saver_fade_in_ms', 'screen_saver_wake_on_touch',
+                    'screen_saver_wake_topic'];
     
     fields.forEach(field => {
         const element = document.querySelector(`[name="${field}"]`);

--- a/src/app/web_portal_config.cpp
+++ b/src/app/web_portal_config.cpp
@@ -130,6 +130,9 @@ void handleGetConfig(AsyncWebServerRequest *request) {
 				(*doc)["screen_saver_fade_out_ms"] = current_config->screen_saver_fade_out_ms;
 				(*doc)["screen_saver_fade_in_ms"] = current_config->screen_saver_fade_in_ms;
 				(*doc)["screen_saver_wake_on_touch"] = current_config->screen_saver_wake_on_touch;
+				#if HAS_MQTT
+				(*doc)["screen_saver_wake_topic"] = current_config->screen_saver_wake_topic;
+				#endif
 				#endif
 
 				if (doc->overflowed()) {
@@ -528,6 +531,12 @@ void handlePostConfig(AsyncWebServerRequest *request, uint8_t *data, size_t len,
 						current_config->screen_saver_wake_on_touch = (bool)(doc["screen_saver_wake_on_touch"] | false);
 				}
 		}
+		#if HAS_MQTT
+		if (doc.containsKey("screen_saver_wake_topic")) {
+				const char *v = doc["screen_saver_wake_topic"] | "";
+				strlcpy(current_config->screen_saver_wake_topic, v, sizeof(current_config->screen_saver_wake_topic));
+		}
+		#endif
 		#endif
 
 		current_config->magic = CONFIG_MAGIC;

--- a/src/app/wifi_manager.cpp
+++ b/src/app/wifi_manager.cpp
@@ -27,29 +27,32 @@ RTC_DATA_ATTR static uint8_t g_cached_channel = 0;
 RTC_DATA_ATTR static bool g_cached_valid = false;
 RTC_DATA_ATTR static char g_cached_ssid[CONFIG_SSID_MAX_LEN] = {0};
 
-// Synchronous gateway ping: returns true if gateway responded.
+// Non-blocking gateway ping state machine.
+// wifi_ping_start() fires a single ICMP ping to the gateway and returns immediately.
+// wifi_ping_collect() reads the result; call it on the *next* watchdog tick.
+// This prevents wifi_manager_watchdog() from blocking loop() while the gateway is slow.
+
+enum class PingState { Idle, Pending };
+static PingState g_ping_state = PingState::Idle;
 static volatile bool g_ping_success = false;
 static volatile bool g_ping_done = false;
+static esp_ping_handle_t g_ping_hdl = nullptr;
 
-static void ping_on_success(esp_ping_handle_t hdl, void *) {
-		g_ping_success = true;
-}
-static void ping_on_timeout(esp_ping_handle_t hdl, void *) {
-		// timeout counts as failure; no action needed here
-}
-static void ping_on_end(esp_ping_handle_t hdl, void *) {
-		g_ping_done = true;
-}
+static void ping_on_success(esp_ping_handle_t, void *) { g_ping_success = true; }
+static void ping_on_timeout(esp_ping_handle_t, void *) {}
+static void ping_on_end(esp_ping_handle_t, void *)     { g_ping_done = true; }
 
-static bool wifi_ping_gateway(uint32_t timeout_ms = 3000) {
+// Fire an async ping to the gateway. Returns false if the session could not be created.
+static bool wifi_ping_start() {
 		IPAddress gw = WiFi.gatewayIP();
 		if (gw == IPAddress(0, 0, 0, 0)) return false;
+		if (g_ping_hdl) return false; // session already running
 
 		esp_ping_config_t cfg = ESP_PING_DEFAULT_CONFIG();
 		cfg.target_addr.u_addr.ip4.addr = gw;
 		cfg.target_addr.type = ESP_IPADDR_TYPE_V4;
 		cfg.count = 1;
-		cfg.timeout_ms = timeout_ms;
+		cfg.timeout_ms = 2000;
 		cfg.interval_ms = 0;
 		cfg.task_stack_size = 2048;
 		cfg.task_prio = 5;
@@ -57,24 +60,28 @@ static bool wifi_ping_gateway(uint32_t timeout_ms = 3000) {
 		esp_ping_callbacks_t cbs = {};
 		cbs.on_ping_success = ping_on_success;
 		cbs.on_ping_timeout = ping_on_timeout;
-		cbs.on_ping_end = ping_on_end;
+		cbs.on_ping_end     = ping_on_end;
 
 		g_ping_success = false;
-		g_ping_done = false;
+		g_ping_done    = false;
 
-		esp_ping_handle_t hdl;
-		if (esp_ping_new_session(&cfg, &cbs, &hdl) != ESP_OK) return false;
-
-		esp_ping_start(hdl);
-
-		const unsigned long start = millis();
-		while (!g_ping_done && (millis() - start) < (timeout_ms + 1000)) {
-				delay(50);
+		if (esp_ping_new_session(&cfg, &cbs, &g_ping_hdl) != ESP_OK) {
+				g_ping_hdl = nullptr;
+				return false;
 		}
+		esp_ping_start(g_ping_hdl);
+		return true;
+}
 
-		esp_ping_stop(hdl);
-		esp_ping_delete_session(hdl);
-		return g_ping_success;
+// Check whether the previously started ping has completed.
+// Returns true if done (result in *success_out), false if still pending.
+static bool wifi_ping_collect(bool *success_out) {
+		if (!g_ping_hdl || !g_ping_done) return false;
+		esp_ping_stop(g_ping_hdl);
+		esp_ping_delete_session(g_ping_hdl);
+		g_ping_hdl = nullptr;
+		if (success_out) *success_out = g_ping_success;
+		return true;
 }
 
 static void format_bssid(const uint8_t *bssid, char *out, size_t out_len) {
@@ -421,6 +428,7 @@ void wifi_manager_watchdog(const DeviceConfig *config, bool config_loaded, bool 
 		if (WiFi.status() != WL_CONNECTED && strlen(config->wifi_ssid) > 0) {
 				LOGW("WiFi", "Watchdog: connection lost - attempting reconnect");
 				g_ping_fail_count = 0;
+				g_ping_state = PingState::Idle;
 				if (wifi_manager_connect(config, false)) {
 						power_manager_note_wifi_success();
 						wifi_manager_start_mdns(config);
@@ -429,22 +437,36 @@ void wifi_manager_watchdog(const DeviceConfig *config, bool config_loaded, bool 
 		}
 
 		// Even when WiFi.status() reports connected, the gateway can become
-		// unreachable (e.g., after a router restart). Detect this by pinging
-		// the gateway and force a reconnect after PING_FAIL_THRESHOLD failures.
+		// unreachable (e.g., after a router restart). Use a two-tick non-blocking
+		// ping so the watchdog never stalls loop() waiting for a response.
+		//
+		// Tick N:   fire ping and return immediately (PingState::Pending)
+		// Tick N+1: collect result, update fail counter, reconnect if needed
 		if (WiFi.status() == WL_CONNECTED) {
-				if (!wifi_ping_gateway()) {
-						g_ping_fail_count++;
-						LOGW("WiFi", "Gateway ping failed (%d/%d)", g_ping_fail_count, PING_FAIL_THRESHOLD);
-						if (g_ping_fail_count >= PING_FAIL_THRESHOLD) {
-								LOGW("WiFi", "Gateway unreachable — forcing reconnect");
-								g_ping_fail_count = 0;
-								if (wifi_manager_connect(config, false)) {
-										power_manager_note_wifi_success();
-										wifi_manager_start_mdns(config);
-								}
+				if (g_ping_state == PingState::Idle) {
+						if (wifi_ping_start()) {
+								g_ping_state = PingState::Pending;
 						}
 				} else {
-						g_ping_fail_count = 0;
+						bool success = false;
+						if (wifi_ping_collect(&success)) {
+								g_ping_state = PingState::Idle;
+								if (!success) {
+										g_ping_fail_count++;
+										LOGW("WiFi", "Gateway ping failed (%d/%d)", g_ping_fail_count, PING_FAIL_THRESHOLD);
+										if (g_ping_fail_count >= PING_FAIL_THRESHOLD) {
+												LOGW("WiFi", "Gateway unreachable — forcing reconnect");
+												g_ping_fail_count = 0;
+												if (wifi_manager_connect(config, false)) {
+														power_manager_note_wifi_success();
+														wifi_manager_start_mdns(config);
+												}
+										}
+								} else {
+										g_ping_fail_count = 0;
+								}
+						}
+						// If ping not done yet it will be collected on the next tick
 				}
 		}
 }

--- a/src/app/wifi_manager.cpp
+++ b/src/app/wifi_manager.cpp
@@ -9,17 +9,73 @@
 #include <WiFi.h>
 #include <ESPmDNS.h>
 #include <lwip/netif.h>
+#include <ping/ping_sock.h>
+#include <esp_ping.h>
 
 // WiFi retry settings
 static constexpr unsigned long WIFI_BACKOFF_BASE = 3000; // 3 seconds base
 static constexpr unsigned long WIFI_CHECK_INTERVAL_MS = 10000; // 10 seconds
 
+// Gateway ping watchdog: reconnect after this many consecutive ping failures
+static constexpr uint8_t PING_FAIL_THRESHOLD = 3;
+
 static unsigned long g_last_wifi_check_ms = 0;
+static uint8_t g_ping_fail_count = 0;
 
 RTC_DATA_ATTR static uint8_t g_cached_bssid[6] = {0};
 RTC_DATA_ATTR static uint8_t g_cached_channel = 0;
 RTC_DATA_ATTR static bool g_cached_valid = false;
 RTC_DATA_ATTR static char g_cached_ssid[CONFIG_SSID_MAX_LEN] = {0};
+
+// Synchronous gateway ping: returns true if gateway responded.
+static volatile bool g_ping_success = false;
+static volatile bool g_ping_done = false;
+
+static void ping_on_success(esp_ping_handle_t hdl, void *) {
+		g_ping_success = true;
+}
+static void ping_on_timeout(esp_ping_handle_t hdl, void *) {
+		// timeout counts as failure; no action needed here
+}
+static void ping_on_end(esp_ping_handle_t hdl, void *) {
+		g_ping_done = true;
+}
+
+static bool wifi_ping_gateway(uint32_t timeout_ms = 3000) {
+		IPAddress gw = WiFi.gatewayIP();
+		if (gw == IPAddress(0, 0, 0, 0)) return false;
+
+		esp_ping_config_t cfg = ESP_PING_DEFAULT_CONFIG();
+		cfg.target_addr.u_addr.ip4.addr = gw;
+		cfg.target_addr.type = ESP_IPADDR_TYPE_V4;
+		cfg.count = 1;
+		cfg.timeout_ms = timeout_ms;
+		cfg.interval_ms = 0;
+		cfg.task_stack_size = 2048;
+		cfg.task_prio = 5;
+
+		esp_ping_callbacks_t cbs = {};
+		cbs.on_ping_success = ping_on_success;
+		cbs.on_ping_timeout = ping_on_timeout;
+		cbs.on_ping_end = ping_on_end;
+
+		g_ping_success = false;
+		g_ping_done = false;
+
+		esp_ping_handle_t hdl;
+		if (esp_ping_new_session(&cfg, &cbs, &hdl) != ESP_OK) return false;
+
+		esp_ping_start(hdl);
+
+		const unsigned long start = millis();
+		while (!g_ping_done && (millis() - start) < (timeout_ms + 1000)) {
+				delay(50);
+		}
+
+		esp_ping_stop(hdl);
+		esp_ping_delete_session(hdl);
+		return g_ping_success;
+}
 
 static void format_bssid(const uint8_t *bssid, char *out, size_t out_len) {
 		if (!out || out_len < 18) return;
@@ -120,7 +176,15 @@ bool wifi_manager_connect(const DeviceConfig *config, bool allow_cached_bssid) {
 		// Instead, just set STA mode and let the hosted link come up cleanly.
 		WiFi.mode(WIFI_STA);
 		LOGI("WiFi", "Waiting for ESP-Hosted link...");
-		delay(5000);
+		// Poll for MAC availability (up to 8 s) instead of a fixed delay.
+		{
+				const unsigned long p4_start = millis();
+				while (millis() - p4_start < 8000) {
+						String mac = WiFi.macAddress();
+						if (mac.length() > 0 && mac != "00:00:00:00:00:00") break;
+						delay(250);
+				}
+		}
 		#else
 		WiFi.disconnect(true);
 		delay(100);
@@ -223,7 +287,7 @@ bool wifi_manager_connect(const DeviceConfig *config, bool allow_cached_bssid) {
 		for (int attempt = 0; attempt < WIFI_MAX_ATTEMPTS; attempt++) {
 				if (attempt > 0) {
 						WiFi.disconnect(false);
-						delay(2000);
+						delay(500);
 				}
 				LOGI("WiFi", "Attempt %d/%d", attempt + 1, WIFI_MAX_ATTEMPTS);
 				WiFi.begin(config->wifi_ssid, config->wifi_password);
@@ -352,14 +416,35 @@ void wifi_manager_watchdog(const DeviceConfig *config, bool config_loaded, bool 
 
 		const unsigned long now = millis();
 		if (now - g_last_wifi_check_ms < WIFI_CHECK_INTERVAL_MS) return;
+		g_last_wifi_check_ms = now;
 
 		if (WiFi.status() != WL_CONNECTED && strlen(config->wifi_ssid) > 0) {
-				LOGW("WIFI", "Watchdog: connection lost - attempting reconnect");
+				LOGW("WiFi", "Watchdog: connection lost - attempting reconnect");
+				g_ping_fail_count = 0;
 				if (wifi_manager_connect(config, false)) {
 						power_manager_note_wifi_success();
 						wifi_manager_start_mdns(config);
 				}
+				return;
 		}
 
-		g_last_wifi_check_ms = now;
+		// Even when WiFi.status() reports connected, the gateway can become
+		// unreachable (e.g., after a router restart). Detect this by pinging
+		// the gateway and force a reconnect after PING_FAIL_THRESHOLD failures.
+		if (WiFi.status() == WL_CONNECTED) {
+				if (!wifi_ping_gateway()) {
+						g_ping_fail_count++;
+						LOGW("WiFi", "Gateway ping failed (%d/%d)", g_ping_fail_count, PING_FAIL_THRESHOLD);
+						if (g_ping_fail_count >= PING_FAIL_THRESHOLD) {
+								LOGW("WiFi", "Gateway unreachable — forcing reconnect");
+								g_ping_fail_count = 0;
+								if (wifi_manager_connect(config, false)) {
+										power_manager_note_wifi_success();
+										wifi_manager_start_mdns(config);
+								}
+						}
+				} else {
+						g_ping_fail_count = 0;
+				}
+		}
 }

--- a/src/version.h
+++ b/src/version.h
@@ -6,7 +6,7 @@
 // Firmware version information
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 0
-#define VERSION_PATCH 57
+#define VERSION_PATCH 58
 
 // Build date (automatically set by compiler)
 #define BUILD_DATE __DATE__

--- a/tests/Arduino.h
+++ b/tests/Arduino.h
@@ -1,0 +1,20 @@
+#pragma once
+// Arduino.h shim for host-native tests.
+// Provides only types needed by the translation units under test.
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+// Minimal String class for compilation only
+// (tested functions use C strings; String is only needed for get_default_device_name)
+#include <string>
+struct String : public std::string {
+    String() : std::string() {}
+    String(const char *s) : std::string(s ? s : "") {}
+    String(std::string s) : std::string(s) {}
+    const char *c_str() const { return std::string::c_str(); }
+    size_t length() const { return std::string::length(); }
+};
+
+inline unsigned long millis() { return 0; }

--- a/tests/board_config.h
+++ b/tests/board_config.h
@@ -1,0 +1,8 @@
+#pragma once
+// Minimal board_config shim for host-native tests.
+// Only defines what the tested translation units require.
+#define HAS_MQTT false
+#define HAS_BLE  false
+#define HAS_DISPLAY false
+#define HAS_TOUCH false
+#define HEALTH_HISTORY_ENABLED 0

--- a/tests/log_manager.h
+++ b/tests/log_manager.h
@@ -1,0 +1,8 @@
+#pragma once
+// Minimal log_manager shim for host-native tests.
+// Silences all logging macros without requiring Arduino headers.
+#include <cstdio>
+#define LOGI(tag, fmt, ...) do { (void)(tag); } while(0)
+#define LOGD(tag, fmt, ...) do { (void)(tag); } while(0)
+#define LOGW(tag, fmt, ...) do { (void)(tag); } while(0)
+#define LOGE(tag, fmt, ...) do { (void)(tag); } while(0)

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# run_tests.sh — build and run host-native unit tests
+#
+# Tests are compiled with g++ and run locally. No Arduino SDK or ESP32
+# toolchain is required.
+#
+# Usage:
+#   ./tests/run_tests.sh         # run all tests
+#   ./tests/run_tests.sh -v      # verbose output
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SRC="$REPO_ROOT/src/app"
+
+VERBOSE=0
+for arg in "$@"; do
+    [[ "$arg" == "-v" ]] && VERBOSE=1
+done
+
+CXX="${CXX:-g++}"
+CXXFLAGS="-std=c++17 -O0 -g -Wall -Wextra
+    -I$SCRIPT_DIR
+    -I$SRC
+    -include $SCRIPT_DIR/log_manager.h
+    -include $SCRIPT_DIR/board_config.h"
+
+TMPDIR_="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_"' EXIT
+
+passed_suites=0
+failed_suites=0
+
+run_test() {
+    local name="$1"
+    local sources="${@:2}"
+    local bin="$TMPDIR_/$name"
+
+    if [[ "$VERBOSE" -eq 1 ]]; then
+        echo "Compiling $name..."
+    fi
+
+    # shellcheck disable=SC2086
+    if $CXX $CXXFLAGS -o "$bin" $sources "$SCRIPT_DIR/stubs.cpp" 2>&1; then
+        local output
+        output=$("$bin" 2>&1)
+        local status=$?
+        echo "$output"
+        if [[ $status -eq 0 ]]; then
+            passed_suites=$((passed_suites + 1))
+        else
+            failed_suites=$((failed_suites + 1))
+        fi
+    else
+        echo "FAIL: $name — compile error"
+        failed_suites=$((failed_suites + 1))
+    fi
+}
+
+echo "=== Running unit tests ==="
+
+run_test test_power_config \
+    "$SCRIPT_DIR/test_power_config.cpp"
+
+run_test test_config_sanitize \
+    "$SCRIPT_DIR/test_config_sanitize.cpp"
+
+echo ""
+echo "=== Test suites: $passed_suites passed, $failed_suites failed ==="
+
+[[ $failed_suites -eq 0 ]] && exit 0 || exit 1

--- a/tests/stubs.cpp
+++ b/tests/stubs.cpp
@@ -1,0 +1,16 @@
+// Minimal Arduino / ESP32 stubs for host-native unit tests.
+// Provides only what the tested source files actually need.
+
+#include <string.h>
+
+// strlcpy is a BSD extension not present on all Linux glibc builds.
+#ifndef HAVE_STRLCPY
+size_t strlcpy(char *dst, const char *src, size_t size) {
+    if (!dst || size == 0) return src ? strlen(src) : 0;
+    size_t len = strlen(src);
+    size_t copy = len < size - 1 ? len : size - 1;
+    memcpy(dst, src, copy);
+    dst[copy] = '\0';
+    return len;
+}
+#endif

--- a/tests/test_config_sanitize.cpp
+++ b/tests/test_config_sanitize.cpp
@@ -1,0 +1,141 @@
+// Unit tests for config_manager_sanitize_device_name().
+// Compiled and run natively on the host (no Arduino SDK required).
+//
+// We only test the pure string-processing function here; NVS/Preferences
+// code is never reached and is not compiled.
+
+#include <cassert>
+#include <cstring>
+#include <cstdio>
+
+// Inject test stubs
+#include "board_config.h"
+#include "log_manager.h"
+
+// Pull in only the sanitize function by extracting the relevant portion
+// of config_manager.cpp through a header-only declaration + inline copy.
+// Avoids dragging in Preferences.h / nvs_flash.h which are ESP32-only.
+
+// Prototype
+void config_manager_sanitize_device_name(const char *input, char *output, size_t max_len);
+
+// Implementation (copy of the pure-C++ function — no ESP32 deps)
+void config_manager_sanitize_device_name(const char *input, char *output, size_t max_len) {
+    if (!input || !output || max_len == 0) return;
+
+    size_t j = 0;
+    for (size_t i = 0; input[i] != '\0' && j < max_len - 1; i++) {
+        char c = input[i];
+        if (c >= 'A' && c <= 'Z') c = c + ('a' - 'A');
+        if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
+            output[j++] = c;
+        } else if (c == ' ' || c == '_' || c == '-') {
+            if (j > 0 && output[j-1] != '-') output[j++] = '-';
+        }
+    }
+    if (j > 0 && output[j-1] == '-') j--;
+    output[j] = '\0';
+}
+
+static int passed = 0;
+static int failed = 0;
+
+#define CHECK_STR(result, expected, msg) do { \
+    if (strcmp((result), (expected)) == 0) { passed++; } \
+    else { failed++; printf("FAIL: %s  (got '%s' expected '%s')\n", msg, result, expected); } \
+} while(0)
+
+static void sanitize(const char *input, char *output, size_t maxlen) {
+    config_manager_sanitize_device_name(input, output, maxlen);
+}
+
+static void test_basic_lowercase() {
+    char out[64];
+    sanitize("MyDevice", out, sizeof(out));
+    CHECK_STR(out, "mydevice", "lowercase conversion");
+}
+
+static void test_spaces_become_hyphens() {
+    char out[64];
+    sanitize("My Device", out, sizeof(out));
+    CHECK_STR(out, "my-device", "space to hyphen");
+}
+
+static void test_underscores_become_hyphens() {
+    char out[64];
+    sanitize("my_device", out, sizeof(out));
+    CHECK_STR(out, "my-device", "underscore to hyphen");
+}
+
+static void test_no_consecutive_hyphens() {
+    char out[64];
+    sanitize("my  device", out, sizeof(out));
+    CHECK_STR(out, "my-device", "multiple spaces -> single hyphen");
+
+    sanitize("my--device", out, sizeof(out));
+    CHECK_STR(out, "my-device", "double hyphen -> single hyphen");
+}
+
+static void test_no_leading_hyphen() {
+    char out[64];
+    sanitize(" device", out, sizeof(out));
+    CHECK_STR(out, "device", "leading space stripped");
+}
+
+static void test_no_trailing_hyphen() {
+    char out[64];
+    sanitize("device ", out, sizeof(out));
+    CHECK_STR(out, "device", "trailing space stripped");
+}
+
+static void test_special_chars_removed() {
+    char out[64];
+    sanitize("device!@#$%", out, sizeof(out));
+    CHECK_STR(out, "device", "special chars removed");
+}
+
+static void test_numbers_preserved() {
+    char out[64];
+    sanitize("esp32c6", out, sizeof(out));
+    CHECK_STR(out, "esp32c6", "numbers preserved");
+}
+
+static void test_empty_input() {
+    char out[64];
+    out[0] = 'x';
+    sanitize("", out, sizeof(out));
+    CHECK_STR(out, "", "empty input -> empty output");
+}
+
+static void test_null_safety() {
+    char out[64];
+    out[0] = 'x';
+    sanitize(nullptr, out, sizeof(out));
+    // Function returns without touching out; no crash is the assertion
+    passed++;
+}
+
+static void test_max_len_respected() {
+    char out[5];
+    sanitize("abcdefghij", out, sizeof(out));
+    // Should be truncated to 4 chars + null
+    if (strlen(out) <= 4) passed++;
+    else { failed++; printf("FAIL: max_len not respected (got len %zu)\n", strlen(out)); }
+}
+
+int main() {
+    printf("=== config_manager sanitize tests ===\n");
+    test_basic_lowercase();
+    test_spaces_become_hyphens();
+    test_underscores_become_hyphens();
+    test_no_consecutive_hyphens();
+    test_no_leading_hyphen();
+    test_no_trailing_hyphen();
+    test_special_chars_removed();
+    test_numbers_preserved();
+    test_empty_input();
+    test_null_safety();
+    test_max_len_respected();
+    printf("Results: %d passed, %d failed\n", passed, failed);
+    return failed == 0 ? 0 : 1;
+}

--- a/tests/test_power_config.cpp
+++ b/tests/test_power_config.cpp
@@ -1,0 +1,126 @@
+// Unit tests for power_config.cpp parse functions.
+// Compiled and run natively on the host (no Arduino SDK required).
+
+#include <cassert>
+#include <cstring>
+#include <cstdio>
+
+// Inject test stubs before including the source under test
+#include "board_config.h"
+#include "log_manager.h"
+
+// power_config.h includes board_config.h and config_manager.h (for DeviceConfig)
+// config_manager.h includes <Arduino.h> — resolved by tests/Arduino.h
+#include "../src/app/power_config.h"
+#include "../src/app/power_config.cpp"
+
+static DeviceConfig make_config(const char *power_mode, const char *transport, const char *scope) {
+    DeviceConfig c = {};
+    if (power_mode)  strncpy(c.power_mode, power_mode, sizeof(c.power_mode) - 1);
+    if (transport)   strncpy(c.publish_transport, transport, sizeof(c.publish_transport) - 1);
+    if (scope)       strncpy(c.mqtt_publish_scope, scope, sizeof(c.mqtt_publish_scope) - 1);
+    return c;
+}
+
+static int passed = 0;
+static int failed = 0;
+
+#define CHECK_EQ(a, b, msg) do { \
+    if ((a) == (b)) { passed++; } \
+    else { failed++; printf("FAIL: %s\n", msg); } \
+} while(0)
+
+static void test_power_mode_parse() {
+    DeviceConfig c;
+
+    c = make_config("always_on", nullptr, nullptr);
+    CHECK_EQ(power_config_parse_power_mode(&c), PowerMode::AlwaysOn,    "always_on -> AlwaysOn");
+
+    c = make_config("ALWAYS_ON", nullptr, nullptr);
+    CHECK_EQ(power_config_parse_power_mode(&c), PowerMode::AlwaysOn,    "ALWAYS_ON case-insensitive");
+
+    c = make_config("duty_cycle", nullptr, nullptr);
+    CHECK_EQ(power_config_parse_power_mode(&c), PowerMode::DutyCycle,   "duty_cycle -> DutyCycle");
+
+    c = make_config("config", nullptr, nullptr);
+    CHECK_EQ(power_config_parse_power_mode(&c), PowerMode::Config,      "config -> Config");
+
+    c = make_config("ap", nullptr, nullptr);
+    CHECK_EQ(power_config_parse_power_mode(&c), PowerMode::Ap,          "ap -> Ap");
+
+    c = make_config("unknown_mode", nullptr, nullptr);
+    CHECK_EQ(power_config_parse_power_mode(&c), PowerMode::AlwaysOn,    "unknown -> default AlwaysOn");
+
+    c = make_config("", nullptr, nullptr);
+    CHECK_EQ(power_config_parse_power_mode(&c), PowerMode::AlwaysOn,    "empty -> default AlwaysOn");
+
+    CHECK_EQ(power_config_parse_power_mode(nullptr), PowerMode::AlwaysOn, "null -> default AlwaysOn");
+}
+
+static void test_transport_parse() {
+    DeviceConfig c;
+
+    c = make_config(nullptr, "ble", nullptr);
+    CHECK_EQ(power_config_parse_publish_transport(&c), PublishTransport::Ble, "ble -> Ble");
+
+    c = make_config(nullptr, "BLE", nullptr);
+    CHECK_EQ(power_config_parse_publish_transport(&c), PublishTransport::Ble, "BLE case-insensitive");
+
+    c = make_config(nullptr, "mqtt", nullptr);
+    CHECK_EQ(power_config_parse_publish_transport(&c), PublishTransport::Mqtt, "mqtt -> Mqtt");
+
+    c = make_config(nullptr, "ble_mqtt", nullptr);
+    CHECK_EQ(power_config_parse_publish_transport(&c), PublishTransport::BleMqtt, "ble_mqtt -> BleMqtt");
+
+    c = make_config(nullptr, "mqtt_ble", nullptr);
+    CHECK_EQ(power_config_parse_publish_transport(&c), PublishTransport::BleMqtt, "mqtt_ble -> BleMqtt");
+
+    c = make_config(nullptr, "unknown", nullptr);
+    CHECK_EQ(power_config_parse_publish_transport(&c), PublishTransport::Ble, "unknown -> default Ble");
+
+    c = make_config(nullptr, "", nullptr);
+    CHECK_EQ(power_config_parse_publish_transport(&c), PublishTransport::Ble, "empty -> default Ble");
+
+    CHECK_EQ(power_config_parse_publish_transport(nullptr), PublishTransport::Ble, "null -> default Ble");
+}
+
+static void test_mqtt_scope_parse() {
+    DeviceConfig c;
+
+    c = make_config(nullptr, nullptr, "sensors_only");
+    CHECK_EQ(power_config_parse_mqtt_publish_scope(&c), MqttPublishScope::SensorsOnly, "sensors_only");
+
+    c = make_config(nullptr, nullptr, "SENSORS_ONLY");
+    CHECK_EQ(power_config_parse_mqtt_publish_scope(&c), MqttPublishScope::SensorsOnly, "SENSORS_ONLY case-insensitive");
+
+    c = make_config(nullptr, nullptr, "diagnostics_only");
+    CHECK_EQ(power_config_parse_mqtt_publish_scope(&c), MqttPublishScope::DiagnosticsOnly, "diagnostics_only");
+
+    c = make_config(nullptr, nullptr, "all");
+    CHECK_EQ(power_config_parse_mqtt_publish_scope(&c), MqttPublishScope::All, "all");
+
+    c = make_config(nullptr, nullptr, "unknown");
+    CHECK_EQ(power_config_parse_mqtt_publish_scope(&c), MqttPublishScope::SensorsOnly, "unknown -> default SensorsOnly");
+
+    CHECK_EQ(power_config_parse_mqtt_publish_scope(nullptr), MqttPublishScope::SensorsOnly, "null -> default SensorsOnly");
+}
+
+static void test_transport_helpers() {
+    CHECK_EQ(power_config_transport_includes_ble(PublishTransport::Ble), true, "Ble includes ble");
+    CHECK_EQ(power_config_transport_includes_ble(PublishTransport::BleMqtt), true, "BleMqtt includes ble");
+    CHECK_EQ(power_config_transport_includes_ble(PublishTransport::Mqtt), false, "Mqtt does not include ble");
+
+    CHECK_EQ(power_config_transport_includes_mqtt(PublishTransport::Mqtt), true, "Mqtt includes mqtt");
+    CHECK_EQ(power_config_transport_includes_mqtt(PublishTransport::BleMqtt), true, "BleMqtt includes mqtt");
+    CHECK_EQ(power_config_transport_includes_mqtt(PublishTransport::Ble), false, "Ble does not include mqtt");
+}
+
+int main() {
+    printf("=== power_config tests ===\n");
+    test_power_mode_parse();
+    test_transport_parse();
+    test_mqtt_scope_parse();
+    test_transport_helpers();
+    printf("Results: %d passed, %d failed\n", passed, failed);
+    return failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Release v0.0.58

### Added
- **OTA rollback protection** — `esp_ota_mark_app_valid_cancel_rollback()` at end of `setup()` prevents bootloader from reverting firmware after a clean startup
- **Heap integrity check** — `heap_caps_check_integrity_all()` in 60s heartbeat catches heap corruption close to the source
- **`monitor.sh --log` flag** — `--log` or `--log=<file>` saves serial output to a file via `tee` alongside the terminal
- **`i2c_bus.cpp/h`** — FreeRTOS mutex wrapper for shared I2C bus access across tasks (`i2c_bus_init`, `i2c_bus_lock`, `i2c_bus_unlock`)
- **MQTT subscription infrastructure** — `MqttManager::addSubscription(topic, handler)` with auto-resubscribe after reconnect
- **`mqtt_wake`** — subscribes to a configurable MQTT topic; wakes the screen saver on `ON`/`1`/`true` payload
- **`DeviceConfig.screen_saver_wake_topic`** — 64-byte field (`#if HAS_MQTT && HAS_DISPLAY`), persisted in NVS, exposed in Home page UI and REST API
- **Host-native unit tests** — `tests/` directory with `run_tests.sh`, stub headers, and 40 test cases covering `power_config` parse functions and `config_manager_sanitize_device_name`
- **Unit test CI job** — `unit-tests` step in `build.yml` runs before firmware builds
- **`DisplayManager::goBack()` + `display_manager_go_back()`** — navigate back through an 8-deep screen history stack
- **WiFi gateway ping watchdog** — forces reconnect after 3 consecutive failed gateway pings, even when `WiFi.status()` still reports connected

### Changed
- `DisplayManager` navigation history: single `previousScreen` pointer replaced with 8-entry `screenHistory` stack; splash excluded from history
- ESP32-P4 WiFi startup: `delay(5000)` → MAC-address polling loop (250ms poll, 8s cap)
- ESP32-P4 WiFi retry delay: 2000ms → 500ms between reconnect attempts
